### PR TITLE
refactor: extract shared utilities into tmux-lib.sh

### DIFF
--- a/.bin/setup/mac.sh
+++ b/.bin/setup/mac.sh
@@ -44,7 +44,7 @@ install_brew_packages() {
     local mac_software=(
         coreutils moreutils findutils bash bash-completion2 wget
         openssh screen git-lfs lua pv p7zip pigz rename ssh-copy-id
-        vbindiff zopfli gnu-sed node deno hugo bat
+        vbindiff zopfli gnu-sed node deno hugo bat zoxide tree jq
         imagemagick pkg-config pngpaste kanata
         jesseduffield/lazydocker/lazydocker kubernetes-cli 1password-cli
         fluxcd/tap/flux

--- a/.bin/tat-preview.sh
+++ b/.bin/tat-preview.sh
@@ -1,18 +1,10 @@
 #!/usr/bin/env zsh
 # tat-preview.sh - fzf preview for project selection
 
-# Ensure PATH includes common locations
-export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+source "$HOME/.bin/tmux-lib.sh"
 
-PROJECT_ROOT="$HOME/projects"
 project="$1"
-path="$PROJECT_ROOT/$project"
-
-# Handle bare repo worktree structure
-if [[ -d "$path/.bare" ]]; then
-    default_branch=$(cd "$path/.bare" && git symbolic-ref --short HEAD 2>/dev/null || echo "main")
-    [[ -d "$path/$default_branch" ]] && path="$path/$default_branch"
-fi
+path=$(resolve_project_path "$PROJECT_ROOT/$project")
 
 [[ ! -d "$path" ]] && { echo "Directory not found: $path"; exit 1; }
 
@@ -27,7 +19,7 @@ if [[ -d "$path/.git" ]] || [[ -d "$path/.bare" ]]; then
 
     echo "Branch: $branch"
 
-    # Status summary using zsh
+    # Status summary
     staged=${#${(f)"$(git diff --cached --numstat 2>/dev/null)"}}
     unstaged=${#${(f)"$(git diff --numstat 2>/dev/null)"}}
     untracked=${#${(f)"$(git ls-files --others --exclude-standard 2>/dev/null)"}}
@@ -44,23 +36,13 @@ if [[ -d "$path/.git" ]] || [[ -d "$path/.bare" ]]; then
 fi
 
 # Project type detection
-print -n "Type: "
-if [[ -f "$path/Cargo.toml" ]]; then
-    echo "Rust"
-elif [[ -f "$path/package.json" ]]; then
-    echo "Node.js"
-    if command -v jq &>/dev/null && [[ -f "$path/package.json" ]]; then
-        scripts=$(jq -r '.scripts | keys | join(", ")' "$path/package.json" 2>/dev/null)
-        [[ -n "$scripts" ]] && echo "Scripts: ${scripts:0:60}"
-    fi
-elif [[ -f "$path/go.mod" ]]; then
-    echo "Go"
-elif [[ -f "$path/pyproject.toml" ]]; then
-    echo "Python (pyproject)"
-elif [[ -f "$path/requirements.txt" ]]; then
-    echo "Python"
-else
-    echo "Unknown"
+project_type=$(detect_project_type "$path")
+echo "Type: $(project_type_display "$project_type")"
+
+# Extra info for Node.js projects
+if [[ "$project_type" == "node" ]] && command -v jq &>/dev/null; then
+    scripts=$(jq -r '.scripts | keys | join(", ")' "$path/package.json" 2>/dev/null)
+    [[ -n "$scripts" ]] && echo "Scripts: ${scripts:0:60}"
 fi
 echo ""
 
@@ -71,7 +53,6 @@ for readme in README.md readme.md README.rst README; do
         if command -v bat &>/dev/null; then
             bat --style=plain --color=always --line-range=:15 "$path/$readme" 2>/dev/null
         else
-            # Use zsh to read first 15 lines
             local i=0
             while IFS= read -r line && (( i++ < 15 )); do
                 echo "$line"

--- a/.bin/tat-preview.sh
+++ b/.bin/tat-preview.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env zsh
+# tat-preview.sh - fzf preview for project selection
+
+PROJECT_ROOT="$HOME/projects"
+project="$1"
+path="$PROJECT_ROOT/$project"
+
+# Handle bare repo worktree structure
+if [[ -d "$path/.bare" ]]; then
+    default_branch=$(cd "$path/.bare" && git symbolic-ref --short HEAD 2>/dev/null || echo "main")
+    [[ -d "$path/$default_branch" ]] && path="$path/$default_branch"
+fi
+
+[[ ! -d "$path" ]] && { echo "Directory not found: $path"; exit 1; }
+
+# Header
+echo "━━━ $project ━━━"
+echo ""
+
+# Git info
+if [[ -d "$path/.git" ]] || [[ -d "$path/.bare" ]]; then
+    cd "$path"
+    branch=$(git branch --show-current 2>/dev/null || echo "detached")
+
+    echo "Branch: $branch"
+
+    # Status summary
+    staged=$(git diff --cached --numstat 2>/dev/null | wc -l | tr -d ' ')
+    unstaged=$(git diff --numstat 2>/dev/null | wc -l | tr -d ' ')
+    untracked=$(git ls-files --others --exclude-standard 2>/dev/null | wc -l | tr -d ' ')
+
+    [[ "$staged" -gt 0 ]] && echo "Staged: $staged"
+    [[ "$unstaged" -gt 0 ]] && echo "Modified: $unstaged"
+    [[ "$untracked" -gt 0 ]] && echo "Untracked: $untracked"
+    [[ "$staged" -eq 0 && "$unstaged" -eq 0 && "$untracked" -eq 0 ]] && echo "Clean"
+
+    echo ""
+    echo "Recent commits:"
+    git log --oneline -5 2>/dev/null | head -5
+    echo ""
+fi
+
+# Project type detection
+echo "Type: \c"
+if [[ -f "$path/Cargo.toml" ]]; then
+    echo "Rust"
+elif [[ -f "$path/package.json" ]]; then
+    echo "Node.js"
+    if command -v jq &>/dev/null && [[ -f "$path/package.json" ]]; then
+        scripts=$(jq -r '.scripts | keys | join(", ")' "$path/package.json" 2>/dev/null | head -c 60)
+        [[ -n "$scripts" ]] && echo "Scripts: $scripts"
+    fi
+elif [[ -f "$path/go.mod" ]]; then
+    echo "Go"
+elif [[ -f "$path/pyproject.toml" ]]; then
+    echo "Python (pyproject)"
+elif [[ -f "$path/requirements.txt" ]]; then
+    echo "Python"
+else
+    echo "Unknown"
+fi
+echo ""
+
+# README preview
+for readme in README.md readme.md README.rst README; do
+    if [[ -f "$path/$readme" ]]; then
+        echo "━━━ README ━━━"
+        if command -v bat &>/dev/null; then
+            bat --style=plain --color=always --line-range=:15 "$path/$readme" 2>/dev/null
+        else
+            head -15 "$path/$readme"
+        fi
+        break
+    fi
+done

--- a/.bin/tat-template.sh
+++ b/.bin/tat-template.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env zsh
+# tat-template.sh - Detect and apply tmux session templates
+
+PROJECT_ROOT="$HOME/projects"
+
+session_name="$1"
+project_path="${2:-$PROJECT_ROOT/$session_name}"
+
+# Handle bare repo worktree structure
+if [[ -d "$project_path/.bare" ]]; then
+    default_branch=$(cd "$project_path/.bare" && git symbolic-ref --short HEAD 2>/dev/null || echo "main")
+    [[ -d "$project_path/$default_branch" ]] && project_path="$project_path/$default_branch"
+fi
+
+# Detect template type
+detect_template() {
+    local path="$1"
+
+    # Explicit override via .tmux-template file
+    [[ -f "$path/.tmux-template" ]] && { cat "$path/.tmux-template"; return; }
+
+    # Auto-detect by markers
+    [[ -f "$path/Cargo.toml" ]] && { echo "rust"; return; }
+    [[ -f "$path/package.json" ]] && { echo "node"; return; }
+    [[ -f "$path/go.mod" ]] && { echo "go"; return; }
+    [[ -f "$path/pyproject.toml" ]] && { echo "python"; return; }
+    [[ -f "$path/requirements.txt" ]] && { echo "python"; return; }
+    [[ -d "$path/cluster" && -f "$path/Makefile" ]] && { echo "kubernetes"; return; }
+
+    echo "default"
+}
+
+# Apply template - creates session with appropriate layout
+apply_template() {
+    local template="$1"
+    local name="$2"
+    local path="$3"
+
+    # Add to zoxide for frecency tracking
+    command -v zoxide &>/dev/null && zoxide add "$path"
+
+    case "$template" in
+        node)
+            tmux new-session -d -s "$name" -c "$path" -n "editor"
+            tmux send-keys -t "$name:editor" "nvim ." Enter
+            tmux split-window -h -t "$name:editor" -c "$path" -l 40%
+            tmux new-window -t "$name" -n "server" -c "$path"
+            tmux new-window -t "$name" -n "git" -c "$path"
+            tmux send-keys -t "$name:git" "lazygit" Enter
+            tmux select-window -t "$name:editor"
+            tmux select-pane -t "$name:editor.0"
+            ;;
+        rust)
+            tmux new-session -d -s "$name" -c "$path" -n "editor"
+            tmux send-keys -t "$name:editor" "nvim ." Enter
+            tmux split-window -h -t "$name:editor" -c "$path" -l 40%
+            tmux new-window -t "$name" -n "git" -c "$path"
+            tmux send-keys -t "$name:git" "lazygit" Enter
+            tmux select-window -t "$name:editor"
+            tmux select-pane -t "$name:editor.0"
+            ;;
+        go)
+            tmux new-session -d -s "$name" -c "$path" -n "editor"
+            tmux send-keys -t "$name:editor" "nvim ." Enter
+            tmux split-window -h -t "$name:editor" -c "$path" -l 40%
+            tmux new-window -t "$name" -n "git" -c "$path"
+            tmux send-keys -t "$name:git" "lazygit" Enter
+            tmux select-window -t "$name:editor"
+            tmux select-pane -t "$name:editor.0"
+            ;;
+        python)
+            tmux new-session -d -s "$name" -c "$path" -n "editor"
+            tmux send-keys -t "$name:editor" "nvim ." Enter
+            tmux split-window -h -t "$name:editor" -c "$path" -l 40%
+            # Activate venv if exists
+            tmux send-keys -t "$name:editor.1" "[ -d .venv ] && source .venv/bin/activate" Enter
+            tmux new-window -t "$name" -n "git" -c "$path"
+            tmux send-keys -t "$name:git" "lazygit" Enter
+            tmux select-window -t "$name:editor"
+            tmux select-pane -t "$name:editor.0"
+            ;;
+        kubernetes)
+            tmux new-session -d -s "$name" -c "$path" -n "editor"
+            tmux send-keys -t "$name:editor" "nvim ." Enter
+            tmux new-window -t "$name" -n "k9s" -c "$path"
+            tmux send-keys -t "$name:k9s" "command -v k9s &>/dev/null && k9s || echo 'k9s not installed'" Enter
+            tmux new-window -t "$name" -n "git" -c "$path"
+            tmux send-keys -t "$name:git" "lazygit" Enter
+            tmux select-window -t "$name:editor"
+            ;;
+        *)
+            # Default: simple single window
+            tmux new-session -d -s "$name" -c "$path"
+            ;;
+    esac
+
+    tmux switch-client -t "$name"
+}
+
+template=$(detect_template "$project_path")
+apply_template "$template" "$session_name" "$project_path"

--- a/.bin/tat-template.sh
+++ b/.bin/tat-template.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env zsh
 # tat-template.sh - Detect and apply tmux session templates
 
+# Ensure PATH includes common locations
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+# Find tmux - needed because PATH may not be available in functions
+TMUX_CMD=$(command -v tmux)
+[[ -z "$TMUX_CMD" ]] && { echo "Error: tmux not found"; exit 1; }
+
 PROJECT_ROOT="$HOME/projects"
 
 session_name="$1"
@@ -41,60 +48,60 @@ apply_template() {
 
     case "$template" in
         node)
-            tmux new-session -d -s "$name" -c "$path" -n "editor"
-            tmux send-keys -t "$name:editor" "nvim ." Enter
-            tmux split-window -h -t "$name:editor" -c "$path" -l 40%
-            tmux new-window -t "$name" -n "server" -c "$path"
-            tmux new-window -t "$name" -n "git" -c "$path"
-            tmux send-keys -t "$name:git" "lazygit" Enter
-            tmux select-window -t "$name:editor"
-            tmux select-pane -t "$name:editor.0"
+            $TMUX_CMD new-session -d -s "$name" -c "$path" -n "editor"
+            $TMUX_CMD send-keys -t "$name:editor" "nvim ." Enter
+            $TMUX_CMD split-window -h -t "$name:editor" -c "$path" -l 40%
+            $TMUX_CMD new-window -t "$name" -n "server" -c "$path"
+            $TMUX_CMD new-window -t "$name" -n "git" -c "$path"
+            $TMUX_CMD send-keys -t "$name:git" "lazygit" Enter
+            $TMUX_CMD select-window -t "$name:editor"
+            $TMUX_CMD select-pane -t "$name:editor.0"
             ;;
         rust)
-            tmux new-session -d -s "$name" -c "$path" -n "editor"
-            tmux send-keys -t "$name:editor" "nvim ." Enter
-            tmux split-window -h -t "$name:editor" -c "$path" -l 40%
-            tmux new-window -t "$name" -n "git" -c "$path"
-            tmux send-keys -t "$name:git" "lazygit" Enter
-            tmux select-window -t "$name:editor"
-            tmux select-pane -t "$name:editor.0"
+            $TMUX_CMD new-session -d -s "$name" -c "$path" -n "editor"
+            $TMUX_CMD send-keys -t "$name:editor" "nvim ." Enter
+            $TMUX_CMD split-window -h -t "$name:editor" -c "$path" -l 40%
+            $TMUX_CMD new-window -t "$name" -n "git" -c "$path"
+            $TMUX_CMD send-keys -t "$name:git" "lazygit" Enter
+            $TMUX_CMD select-window -t "$name:editor"
+            $TMUX_CMD select-pane -t "$name:editor.0"
             ;;
         go)
-            tmux new-session -d -s "$name" -c "$path" -n "editor"
-            tmux send-keys -t "$name:editor" "nvim ." Enter
-            tmux split-window -h -t "$name:editor" -c "$path" -l 40%
-            tmux new-window -t "$name" -n "git" -c "$path"
-            tmux send-keys -t "$name:git" "lazygit" Enter
-            tmux select-window -t "$name:editor"
-            tmux select-pane -t "$name:editor.0"
+            $TMUX_CMD new-session -d -s "$name" -c "$path" -n "editor"
+            $TMUX_CMD send-keys -t "$name:editor" "nvim ." Enter
+            $TMUX_CMD split-window -h -t "$name:editor" -c "$path" -l 40%
+            $TMUX_CMD new-window -t "$name" -n "git" -c "$path"
+            $TMUX_CMD send-keys -t "$name:git" "lazygit" Enter
+            $TMUX_CMD select-window -t "$name:editor"
+            $TMUX_CMD select-pane -t "$name:editor.0"
             ;;
         python)
-            tmux new-session -d -s "$name" -c "$path" -n "editor"
-            tmux send-keys -t "$name:editor" "nvim ." Enter
-            tmux split-window -h -t "$name:editor" -c "$path" -l 40%
+            $TMUX_CMD new-session -d -s "$name" -c "$path" -n "editor"
+            $TMUX_CMD send-keys -t "$name:editor" "nvim ." Enter
+            $TMUX_CMD split-window -h -t "$name:editor" -c "$path" -l 40%
             # Activate venv if exists
-            tmux send-keys -t "$name:editor.1" "[ -d .venv ] && source .venv/bin/activate" Enter
-            tmux new-window -t "$name" -n "git" -c "$path"
-            tmux send-keys -t "$name:git" "lazygit" Enter
-            tmux select-window -t "$name:editor"
-            tmux select-pane -t "$name:editor.0"
+            $TMUX_CMD send-keys -t "$name:editor.1" "[ -d .venv ] && source .venv/bin/activate" Enter
+            $TMUX_CMD new-window -t "$name" -n "git" -c "$path"
+            $TMUX_CMD send-keys -t "$name:git" "lazygit" Enter
+            $TMUX_CMD select-window -t "$name:editor"
+            $TMUX_CMD select-pane -t "$name:editor.0"
             ;;
         kubernetes)
-            tmux new-session -d -s "$name" -c "$path" -n "editor"
-            tmux send-keys -t "$name:editor" "nvim ." Enter
-            tmux new-window -t "$name" -n "k9s" -c "$path"
-            tmux send-keys -t "$name:k9s" "command -v k9s &>/dev/null && k9s || echo 'k9s not installed'" Enter
-            tmux new-window -t "$name" -n "git" -c "$path"
-            tmux send-keys -t "$name:git" "lazygit" Enter
-            tmux select-window -t "$name:editor"
+            $TMUX_CMD new-session -d -s "$name" -c "$path" -n "editor"
+            $TMUX_CMD send-keys -t "$name:editor" "nvim ." Enter
+            $TMUX_CMD new-window -t "$name" -n "k9s" -c "$path"
+            $TMUX_CMD send-keys -t "$name:k9s" "command -v k9s &>/dev/null && k9s || echo 'k9s not installed'" Enter
+            $TMUX_CMD new-window -t "$name" -n "git" -c "$path"
+            $TMUX_CMD send-keys -t "$name:git" "lazygit" Enter
+            $TMUX_CMD select-window -t "$name:editor"
             ;;
         *)
             # Default: simple single window
-            tmux new-session -d -s "$name" -c "$path"
+            $TMUX_CMD new-session -d -s "$name" -c "$path"
             ;;
     esac
 
-    tmux switch-client -t "$name"
+    $TMUX_CMD switch-client -t "$name"
 }
 
 template=$(detect_template "$project_path")

--- a/.bin/tat.sh
+++ b/.bin/tat.sh
@@ -2,19 +2,14 @@
 # tat.sh - Tmux Attach to project
 # Simple session manager with zoxide frecency + fzf preview
 
-# Ensure PATH includes common locations
-export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+source "$HOME/.bin/tmux-lib.sh"
 
-PROJECT_ROOT="$HOME/projects"
+require_tmux
+tmux_init
+require_fzf
+
 PREVIEW_SCRIPT="$HOME/.bin/tat-preview.sh"
 TEMPLATE_SCRIPT="$HOME/.bin/tat-template.sh"
-
-# Require tmux
-[[ -z "$TMUX" ]] && { echo "Error: Run inside tmux"; exit 1; }
-
-# Find tmux command
-TMUX_CMD=$(command -v tmux)
-[[ -z "$TMUX_CMD" ]] && { echo "Error: tmux not found"; exit 1; }
 
 # Get all project directories
 get_projects() {
@@ -58,12 +53,8 @@ build_list() {
     done
 }
 
-# Find fzf
-fzf_cmd=$(command -v fzf || echo "$HOME/.fzf/bin/fzf")
-[[ ! -x "$fzf_cmd" ]] && { echo "Error: fzf not found"; exit 1; }
-
 # Run fzf with preview
-selected=$(build_list | "$fzf_cmd" \
+selected=$(build_list | "$FZF_CMD" \
     --reverse \
     --ansi \
     --header="Select project (preview: git status, readme)" \

--- a/.bin/tat.sh
+++ b/.bin/tat.sh
@@ -1,226 +1,80 @@
 #!/usr/bin/env zsh
-# tat.sh - Tmux session manager for projects across multiple locations
-# Usage: Run inside tmux to select and switch to a project
+# tat.sh - Tmux Attach to project
+# Simple session manager with zoxide frecency + fzf preview
 
-# Define project locations with aliases
-declare -A project_paths=(
-  ["wsl"]="$HOME/projects"
-  ["win"]="/mnt/c/Users/edwinmuraya/projects"
-)
+set -e
 
-# Require tmux session
-if [[ -z "$TMUX" ]]; then
-  echo "Error: This script must be run inside a tmux session."
-  exit 1
-fi
+PROJECT_ROOT="$HOME/projects"
+PREVIEW_SCRIPT="$HOME/.bin/tat-preview.sh"
+TEMPLATE_SCRIPT="$HOME/.bin/tat-template.sh"
 
-# Initialize directories and project sessions lists
-directories=""
-project_sessions=()  # Array to track project session names
+# Require tmux
+[[ -z "$TMUX" ]] && { echo "Error: Run inside tmux"; exit 1; }
 
-# Initialize associative array to track project sources
-typeset -A project_sources
+# Get all project directories
+get_projects() {
+    local projects=()
+    for dir in "$PROJECT_ROOT"/*/; do
+        [[ -d "$dir" ]] || continue
+        local name=$(basename "$dir")
+        [[ "$name" == .* ]] && continue
+        projects+=("$name")
+    done
+    printf '%s\n' "${projects[@]}"
+}
 
-# Get directories from all configured paths
-for key in "${(@k)project_paths}"; do
-  dir_path="${project_paths[$key]}"
-  if [[ -d "$dir_path" ]]; then
-    # Get top-level directories excluding system ones
-    dir_list=$(cd "$dir_path" && find . -maxdepth 1 -type d \
-      -not -path "." \
-      -not -path "./.git" \
-      -not -path "./node_modules" \
-      -not -path "./.vscode" \
-      -not -path "./.idea" \
-      -not -path "./__pycache__" \
-      | sed 's|^\./||g')
-      
-    if [[ -n "$dir_list" ]]; then
-      while IFS= read -r line; do
-        if [[ -n "${project_sources[$line]}" ]]; then
-          project_sources[$line]="${project_sources[$line]} $key"
+# Sort projects by zoxide frecency
+sort_by_frecency() {
+    if command -v zoxide &>/dev/null; then
+        while IFS= read -r project; do
+            local path="$PROJECT_ROOT/$project"
+            local score=$(zoxide query -s "$path" 2>/dev/null | awk '{print $1}')
+            [[ -z "$score" ]] && score="0"
+            echo "$score $project"
+        done | sort -rn | awk '{print $2}'
+    else
+        sort
+    fi
+}
+
+# Check if session exists
+has_session() {
+    tmux has-session -t "=$1" 2>/dev/null
+}
+
+# Build display list with session indicators
+build_list() {
+    get_projects | sort_by_frecency | while IFS= read -r project; do
+        if has_session "$project"; then
+            echo "[*] $project"
         else
-          project_sources[$line]="$key"
+            echo "    $project"
         fi
-      done <<< "$dir_list"
-    fi
-  fi
-done
-
-# Build directories list and project sessions
-for name in "${(@k)project_sources}"; do
-  # Split sources into array
-  sources=(${=project_sources[$name]})
-  
-  if [[ ${#sources[@]} -gt 1 ]]; then
-    # Duplicates exist, add prefix for all
-    for key in "${sources[@]}"; do
-      entry="${key}_${name}"
-      if [[ -n "$directories" ]]; then
-        directories="$directories"$'\n'"$entry"
-      else
-        directories="$entry"
-      fi
-      project_sessions+=("$entry")
     done
-  else
-    # Unique, no prefix
-    entry="$name"
-    if [[ -n "$directories" ]]; then
-      directories="$directories"$'\n'"$entry"
-    else
-      directories="$entry"
-    fi
-    project_sessions+=("$entry")
-  fi
-done
+}
 
-# Sort directories for display
-directories=$(echo "$directories" | sort)
-
-# Get active tmux sessions
-active_sessions=$(tmux list-sessions -F "#S" 2>/dev/null || echo "")
-filtered_sessions=""
-
-# Filter out tmux sessions that match project directories or path keys
-if [[ -n "$active_sessions" ]]; then
-  while IFS= read -r session; do
-    # Check if this session is already in our project list
-    session_in_projects=0
-    for project in "${project_sessions[@]}"; do
-      if [[ "$session" == "$project" ]]; then
-        session_in_projects=1
-        break
-      fi
-    done
-
-    # Also check if this session name matches one of our path keys (wsl, win)
-    if [[ $session_in_projects -eq 0 && " ${(k)project_paths[@]} " == *" $session "* ]]; then
-      session_in_projects=1
-    fi
-
-    # Only add sessions that aren't already represented by a project directory or path key
-    if [[ $session_in_projects -eq 0 ]]; then
-      # Get the session's current path
-      session_path=$(tmux display-message -p -t "$session" '#{pane_current_path}' 2>/dev/null || echo "$HOME")
-      
-      if [[ -n "$filtered_sessions" ]]; then
-        filtered_sessions="$filtered_sessions"$'\n'"path:$session:$session_path"
-      else
-        filtered_sessions="path:$session:$session_path"
-      fi
-    fi
-  done <<< "$active_sessions"
-fi
-# Initialize filtered paths variable
-all_project_paths=""
-filtered_paths=""
-
-# Process project paths and prepare for deduplication
-for key in "${(@k)project_paths}"; do
-  project_path="${project_paths[$key]}"
-  if [[ -d "$project_path" ]]; then
-    if [[ -n "$all_project_paths" ]]; then
-      all_project_paths="$all_project_paths"$'\n'"path $key:$project_path"
-    else
-      all_project_paths="path $key:$project_path"
-    fi
-  fi
-done
-
-# Filter out path entries that are already represented by project directories
-if [[ -n "$all_project_paths" ]]; then
-  # We always include all paths regardless of active sessions
-  # This ensures both WSL and Windows paths are always visible
-  filtered_paths="$all_project_paths"
-fi
-
-# Combine deduplicated lists (project directories, non-duplicate tmux sessions with path: prefix, and non-duplicate paths)
-combined_list=$(echo -e "$directories\n$filtered_sessions\n$filtered_paths" | grep -v '^$' | sort -u)
-
+# Find fzf
 fzf_cmd=$(command -v fzf || echo "$HOME/.fzf/bin/fzf")
+[[ ! -x "$fzf_cmd" ]] && { echo "Error: fzf not found"; exit 1; }
 
-# Check if fzf is available
-if [[ ! -x "$fzf_cmd" ]]; then
-  echo "Error: fzf not found. Please install fzf to use this script."
-  exit 1
-fi
+# Run fzf with preview
+selected=$(build_list | "$fzf_cmd" \
+    --reverse \
+    --ansi \
+    --header="Select project (preview: git status, readme)" \
+    --preview="$PREVIEW_SCRIPT {2}" \
+    --preview-window="right:50%:wrap" \
+    | awk '{print $NF}')
 
-selected=$(echo "$combined_list" | $fzf_cmd --reverse --header="Select project/session/path >")
+# Exit if nothing selected
+[[ -z "$selected" ]] && exit 0
 
-# If nothing selected, exit
-if [[ -z "$selected" ]]; then
-  echo "No selection made. Exiting."
-  exit 1
-fi
+session_name="$selected"
+project_path="$PROJECT_ROOT/$selected"
 
-# Parse selection to get real session name and path
-if [[ $selected == path:* ]]; then
-  # Selected a tmux session
-  # Format is path:NAME:PATH
-  session_name="${selected#path:}"
-  session_name="${session_name%%:*}"
-  path_name="${selected#path:$session_name:}"
-elif [[ $selected == path\ * ]]; then
-  # Selected a project path directly (path KEY:PATH)
-  # Format is "path key:path_value"
-  prefix_name=${selected#path }
-  prefix_name=${prefix_name%%:*}
-  path_name=${selected#path $prefix_name:}
-  session_name=$prefix_name
+# Create or switch to session
+if has_session "$session_name"; then
+    tmux switch-client -t "$session_name"
 else
-  # Selected a directory (prefixed or unique)
-  session_name=$selected
-  path_name=""
-  
-  # 1. Try to parse as prefixed path
-  for key in "${(@k)project_paths}"; do
-    if [[ "$selected" == "${key}_"* ]]; then
-      # Potential prefix match
-      potential_dir="${selected#${key}_}"
-      potential_path="${project_paths[$key]}/$potential_dir"
-      
-      if [[ -d "$potential_path" ]]; then
-        path_name="$potential_path"
-        break
-      fi
-    fi
-  done
-  
-  # 2. If not found as prefixed, try as exact name in any path
-  if [[ -z "$path_name" ]]; then
-    for key in "${(@k)project_paths}"; do
-      potential_path="${project_paths[$key]}/$selected"
-      if [[ -d "$potential_path" ]]; then
-        path_name="$potential_path"
-        break
-      fi
-    done
-  fi
-  
-  # 3. Fallback
-  if [[ -z "$path_name" ]]; then
-     # Default to first configured path
-     for key in "${(@k)project_paths}"; do
-        path_name="${project_paths[$key]}/$selected"
-        break
-     done
-  fi
+    "$TEMPLATE_SCRIPT" "$session_name" "$project_path"
 fi
-
-echo "Session name is \"$session_name\""
-echo "Path name is \"$path_name\""
-
-if [[ -z "$session_name" ]]; then
-  echo "Error: Empty session name"
-  exit 1
-fi
-
-# Only create a new session if it doesn't exist
-if ! tmux has-session -t "=$session_name" 2>/dev/null; then
-  echo "Creating new session: $session_name"
-  tmux new-session -d -s "$session_name" -c "$path_name"
-fi
-
-# Switch to the session
-tmux switch-client -t "$session_name"

--- a/.bin/tmux-lib.sh
+++ b/.bin/tmux-lib.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env zsh
+# tmux-lib.sh - Shared utilities for tmux scripts
+
+# PATH setup
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+# Constants
+PROJECT_ROOT="$HOME/projects"
+
+# Find tmux command and set TMUX_CMD
+tmux_init() {
+    TMUX_CMD=$(command -v tmux)
+    [[ -z "$TMUX_CMD" ]] && { echo "Error: tmux not found"; exit 1; }
+}
+
+# Require running inside tmux
+require_tmux() {
+    [[ -z "$TMUX" ]] && { echo "Error: Run inside tmux"; exit 1; }
+}
+
+# Find fzf command and set FZF_CMD
+require_fzf() {
+    FZF_CMD=$(command -v fzf || echo "$HOME/.fzf/bin/fzf")
+    [[ ! -x "$FZF_CMD" ]] && { echo "Error: fzf not found"; exit 1; }
+}
+
+# Resolve bare repo worktree path
+# Usage: path=$(resolve_project_path "$path")
+resolve_project_path() {
+    local path="$1"
+    if [[ -d "$path/.bare" ]]; then
+        local default_branch=$(cd "$path/.bare" && git symbolic-ref --short HEAD 2>/dev/null || echo "main")
+        [[ -d "$path/$default_branch" ]] && path="$path/$default_branch"
+    fi
+    echo "$path"
+}
+
+# Detect project type by marker files
+# Returns: rust, node, go, python, kubernetes, or default
+detect_project_type() {
+    local path="$1"
+    # Check for explicit override
+    [[ -f "$path/.tmux-template" ]] && { cat "$path/.tmux-template"; return; }
+    # Auto-detect
+    [[ -f "$path/Cargo.toml" ]] && { echo "rust"; return; }
+    [[ -f "$path/package.json" ]] && { echo "node"; return; }
+    [[ -f "$path/go.mod" ]] && { echo "go"; return; }
+    [[ -f "$path/pyproject.toml" ]] && { echo "python"; return; }
+    [[ -f "$path/requirements.txt" ]] && { echo "python"; return; }
+    [[ -d "$path/cluster" && -f "$path/Makefile" ]] && { echo "kubernetes"; return; }
+    echo "default"
+}
+
+# Get display name for project type
+project_type_display() {
+    case "$1" in
+        rust) echo "Rust" ;;
+        node) echo "Node.js" ;;
+        go) echo "Go" ;;
+        python) echo "Python" ;;
+        kubernetes) echo "Kubernetes" ;;
+        *) echo "Unknown" ;;
+    esac
+}
+
+# Base tmux session layout: editor with split + git window
+# Used by rust, go, and as base for other templates
+apply_base_layout() {
+    local name="$1" path="$2"
+    $TMUX_CMD new-session -d -s "$name" -c "$path" -n "editor"
+    $TMUX_CMD send-keys -t "$name:editor" "nvim ." Enter
+    $TMUX_CMD split-window -h -t "$name:editor" -c "$path" -l 40%
+    $TMUX_CMD new-window -t "$name" -n "git" -c "$path"
+    $TMUX_CMD send-keys -t "$name:git" "lazygit" Enter
+    $TMUX_CMD select-window -t "$name:editor"
+    $TMUX_CMD select-pane -t "$name:editor.0"
+}

--- a/.bin/tmux-nav.sh
+++ b/.bin/tmux-nav.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env zsh
+# tmux-nav.sh - Unified fuzzy tmux navigator
+# Usage: Run inside tmux, use symbols to filter:
+#   @  = sessions only
+#   #  = windows only
+#   :  = panes only
+#   (no prefix) = show all
+
+set -e
+
+[[ -z "$TMUX" ]] && { echo "Error: Run inside tmux"; exit 1; }
+
+# Colors for fzf display
+C_SESSION="\033[36m"  # cyan
+C_WINDOW="\033[33m"   # yellow
+C_PANE="\033[35m"     # magenta
+C_RESET="\033[0m"
+C_DIM="\033[2m"
+
+# Current context
+current_session=$(tmux display-message -p '#S')
+current_window=$(tmux display-message -p '#I')
+current_pane=$(tmux display-message -p '#P')
+
+# Build unified list
+build_list() {
+    # Sessions: @session_name (path)
+    tmux list-sessions -F "#{session_name}|#{session_path}|#{session_windows}" 2>/dev/null | while IFS='|' read -r name path windows; do
+        marker=""
+        [[ "$name" == "$current_session" ]] && marker="*"
+        echo -e "@${C_SESSION}${name}${marker}${C_RESET} ${C_DIM}(${windows}w)${C_RESET}"
+    done
+
+    # Windows: #session:window - name
+    tmux list-windows -a -F "#{session_name}|#{window_index}|#{window_name}|#{window_active}" 2>/dev/null | while IFS='|' read -r sess idx name active; do
+        marker=""
+        [[ "$sess" == "$current_session" && "$idx" == "$current_window" ]] && marker="*"
+        echo -e "#${C_WINDOW}${sess}:${idx}${marker}${C_RESET} ${name}"
+    done
+
+    # Panes: :session:window.pane - command (path)
+    tmux list-panes -a -F "#{session_name}|#{window_index}|#{pane_index}|#{pane_current_command}|#{pane_current_path}" 2>/dev/null | while IFS='|' read -r sess win pane cmd path; do
+        marker=""
+        [[ "$sess" == "$current_session" && "$win" == "$current_window" && "$pane" == "$current_pane" ]] && marker="*"
+        short_path="${path/#$HOME/~}"
+        echo -e ":${C_PANE}${sess}:${win}.${pane}${marker}${C_RESET} ${cmd} ${C_DIM}${short_path}${C_RESET}"
+    done
+}
+
+# Preview function based on selection type
+preview_cmd() {
+    local sel="$1"
+    case "$sel" in
+        @*)
+            # Session preview: show windows
+            local session="${sel#@}"
+            session="${session%%\**}"  # Remove marker
+            session="${session%% *}"   # Remove trailing info
+            echo "Session: $session"
+            echo "─────────────────────"
+            tmux list-windows -t "$session" -F "  #I: #W #{?window_active,(active),}" 2>/dev/null
+            echo ""
+            echo "Panes:"
+            tmux list-panes -t "$session" -F "  #I.#P: #{pane_current_command}" 2>/dev/null
+            ;;
+        \#*)
+            # Window preview: show panes
+            local target="${sel#\#}"
+            target="${target%%\**}"
+            target="${target%% *}"
+            echo "Window: $target"
+            echo "─────────────────────"
+            tmux list-panes -t "$target" -F "  Pane #P: #{pane_current_command}" 2>/dev/null
+            tmux capture-pane -t "$target" -p 2>/dev/null | head -20
+            ;;
+        :*)
+            # Pane preview: show content
+            local target="${sel#:}"
+            target="${target%%\**}"
+            target="${target%% *}"
+            echo "Pane: $target"
+            echo "─────────────────────"
+            tmux capture-pane -t "$target" -p 2>/dev/null | head -30
+            ;;
+    esac
+}
+
+# Export for fzf preview
+export -f preview_cmd 2>/dev/null || true
+
+# Find fzf
+fzf_cmd=$(command -v fzf || echo "$HOME/.fzf/bin/fzf")
+[[ ! -x "$fzf_cmd" ]] && { echo "Error: fzf not found"; exit 1; }
+
+# Create temp preview script (needed because fzf preview can't use functions directly)
+preview_script=$(mktemp)
+cat > "$preview_script" << 'PREVIEW'
+#!/usr/bin/env zsh
+sel="$1"
+case "$sel" in
+    @*)
+        session="${sel#@}"
+        session="${session%%\**}"
+        session="${session%% *}"
+        echo "Session: $session"
+        echo "─────────────────────"
+        tmux list-windows -t "$session" -F "  #I: #W #{?window_active,(active),}" 2>/dev/null
+        echo ""
+        echo "Panes:"
+        tmux list-panes -t "$session" -F "  #I.#P: #{pane_current_command}" 2>/dev/null
+        ;;
+    \#*)
+        target="${sel#\#}"
+        target="${target%%\**}"
+        target="${target%% *}"
+        echo "Window: $target"
+        echo "─────────────────────"
+        tmux list-panes -t "$target" -F "  Pane #P: #{pane_current_command}" 2>/dev/null
+        echo ""
+        tmux capture-pane -t "$target" -p 2>/dev/null | head -15
+        ;;
+    :*)
+        target="${sel#:}"
+        target="${target%%\**}"
+        target="${target%% *}"
+        echo "Pane: $target"
+        echo "─────────────────────"
+        tmux capture-pane -t "$target" -p 2>/dev/null | head -25
+        ;;
+esac
+PREVIEW
+chmod +x "$preview_script"
+
+# Run fzf
+selected=$(build_list | "$fzf_cmd" \
+    --ansi \
+    --reverse \
+    --header="@ sessions | # windows | : panes" \
+    --preview="$preview_script {}" \
+    --preview-window="right:40%:wrap" \
+    --bind="@:reload(tmux list-sessions -F '@#S')" \
+    --bind="ctrl-s:reload(tmux list-sessions -F '@#S')" \
+    --bind="ctrl-w:reload(tmux list-windows -a -F '##{session_name}:#{window_index} #{window_name}')" \
+    --bind="ctrl-p:reload(tmux list-panes -a -F ':#{session_name}:#{window_index}.#{pane_index} #{pane_current_command}')")
+
+# Cleanup
+rm -f "$preview_script"
+
+# Exit if nothing selected
+[[ -z "$selected" ]] && exit 0
+
+# Parse and switch
+case "$selected" in
+    @*)
+        # Switch to session
+        target="${selected#@}"
+        target="${target%%\**}"
+        target="${target%% *}"
+        tmux switch-client -t "$target"
+        ;;
+    \#*)
+        # Switch to window
+        target="${selected#\#}"
+        target="${target%%\**}"
+        target="${target%% *}"
+        tmux switch-client -t "$target"
+        ;;
+    :*)
+        # Switch to pane
+        target="${selected#:}"
+        target="${target%%\**}"
+        target="${target%% *}"
+        tmux switch-client -t "$target"
+        ;;
+esac

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,184 +1,230 @@
-##### Core behaviour ###########################################################
+#============================================================================
+# TMUX CONFIGURATION
+#============================================================================
 
-# Allow passthrough (tmux >= 3.4, harmless if unknown)
-set -gq allow-passthrough on
-
-# Visual noise
-set -g visual-activity off
+#----------------------------------------------------------------------------
+# Core Settings
+#----------------------------------------------------------------------------
 
 # Terminal & colors
-set -g default-terminal "screen-256color"        # Change to "tmux-256color" if you have that terminfo
-set -as terminal-overrides ",*:RGB"              # Truecolor for all terms that support it
+set -g default-terminal "tmux-256color"
+set -as terminal-overrides ",*:RGB"
+set -gq allow-passthrough on
 
-# Default shell (guarded)
+# Shell
 if-shell '[ -x /bin/zsh ]' 'set-option -g default-shell /bin/zsh'
 
-# History & scrolling
+# History
 set -g history-limit 100000
 
-# Mouse + window/pane indices
-set -g mouse on
-set -g renumber-windows on
+# Timing
 set -s escape-time 0
+set -g display-panes-time 2000
 
+# Mouse
+set -g mouse on
+
+# Window/pane numbering (start at 1)
 set -g base-index 1
-set-window-option -g pane-base-index 1
+setw -g pane-base-index 1
+set -g renumber-windows on
 
-# How long to show pane numbers after prefix+q
-set -g display-panes-time 100
+# Disable visual noise
+set -g visual-activity off
+set -g visual-bell off
 
+#----------------------------------------------------------------------------
+# Prefix & Core Bindings
+#----------------------------------------------------------------------------
 
-##### Prefix and basic bindings ###############################################
-
-# Change prefix from C-b -> C-Space
+# Prefix: C-Space
 unbind C-b
 set -g prefix C-Space
-
-# Splits keep current path
-bind v split-window -h -c "#{pane_current_path}"
-bind h split-window -v -c "#{pane_current_path}"
-
-# Paste from buffer
-bind-key y paste-buffer
+bind C-Space send-prefix
 
 # Reload config
-bind R source-file ~/.tmux.conf \; refresh-client \; display "Conf Reloaded!"
+bind R source-file ~/.tmux.conf \; display "Config reloaded!"
 
-# Window navigation bindings
-bind -r C-h select-window -t :-     # Previous window
+#----------------------------------------------------------------------------
+# Pane Management
+#----------------------------------------------------------------------------
 
-unbind n
-bind n select-window -t 1
-bind e select-window -t 2
-bind i select-window -t 3
-bind l select-window -t 4
-bind y select-window -t 5
+# Splits (v=right, s=below) - keeps current path
+bind v split-window -h -c "#{pane_current_path}"
+bind s split-window -v -c "#{pane_current_path}"
 
-# New window in current dir
+# Pane navigation (arrow keys)
+bind -r Left select-pane -L
+bind -r Down select-pane -D
+bind -r Up select-pane -U
+bind -r Right select-pane -R
+
+# Pane resizing (shift + arrow)
+bind -r S-Left resize-pane -L 5
+bind -r S-Down resize-pane -D 5
+bind -r S-Up resize-pane -U 5
+bind -r S-Right resize-pane -R 5
+
+# Swap panes
+bind S display-panes \; command-prompt -p "Swap with:" "swap-pane -t '%%'"
+
+# Join pane from another window
+bind J command-prompt -p "Join from:" "join-pane -h -s '%%'"
+
+# Kill pane (with confirm)
+bind q confirm-before -p "Kill pane? (y/n)" kill-pane
+
+# Toggle zoom
+bind z resize-pane -Z
+
+#----------------------------------------------------------------------------
+# Window Management
+#----------------------------------------------------------------------------
+
+# New window (keeps path)
 bind w new-window -c "#{pane_current_path}"
 
 # Rename window
-bind r command-prompt -p 'Rename Window:' 'rename-window "%%"'
+bind r command-prompt -p "Rename:" "rename-window '%%'"
 
-# Quit pane with confirm
-bind-key q confirm-before -p "Quit pane @P? (y/n)" kill-pane
+# Direct window access
+bind 1 select-window -t 1
+bind 2 select-window -t 2
+bind 3 select-window -t 3
+bind 4 select-window -t 4
+bind 5 select-window -t 5
 
+# Previous/next window
+bind -r [ previous-window
+bind -r ] next-window
 
-##### Copy mode (vi-style + system clipboard) ##################################
+# Move windows left/right
+bind -r < swap-window -t -1 \; previous-window
+bind -r > swap-window -t +1 \; next-window
 
-# Enter copy-mode
-bind-key Space copy-mode
+#----------------------------------------------------------------------------
+# Session Management
+#----------------------------------------------------------------------------
 
-# Core vi copy-mode movement
-bind-key -T copy-mode-vi v  send -X begin-selection
-bind-key -T copy-mode-vi C-v send -X rectangle-toggle
-bind-key -T copy-mode-vi C-u send -X halfpage-up
-bind-key -T copy-mode-vi C-d send -X halfpage-down
-bind-key -T copy-mode-vi g  send -X top-line
-bind-key -T copy-mode-vi G  send -X bottom-line
+# Project picker (tat.sh with preview)
+bind C-o display-popup -E -w 80% -h 80% "$HOME/.bin/tat.sh"
+
+# Unified tmux navigator (@ sessions, # windows, : panes)
+bind C-n display-popup -E -w 70% -h 70% "$HOME/.bin/tmux-nav.sh"
+
+# Session tree
+bind C-s choose-tree -Zs
+
+# Kill session and switch to next
+bind t run-shell '(tmux switch-client -l || tmux switch-client -n) && tmux kill-session -t "#S" || tmux kill-session'
+
+# Rename session
+bind $ command-prompt -p "Rename session:" "rename-session '%%'"
+
+#----------------------------------------------------------------------------
+# Copy Mode (vi-style)
+#----------------------------------------------------------------------------
+
+setw -g mode-keys vi
+
+# Enter copy mode
+bind Space copy-mode
+
+# Selection
+bind -T copy-mode-vi v send -X begin-selection
+bind -T copy-mode-vi C-v send -X rectangle-toggle
+bind -T copy-mode-vi y send -X copy-selection-and-cancel
+
+# Navigation
+bind -T copy-mode-vi C-u send -X halfpage-up
+bind -T copy-mode-vi C-d send -X halfpage-down
+bind -T copy-mode-vi g send -X history-top
+bind -T copy-mode-vi G send -X history-bottom
 
 # Search
-bind-key -T copy-mode-vi / command-prompt "search-forward '%%'"
-bind-key -T copy-mode-vi ? command-prompt "search-backward '%%'"
-bind-key -T copy-mode-vi n send -X search-again
-bind-key -T copy-mode-vi N send -X search-reverse
+bind -T copy-mode-vi / command-prompt -p "/" "send -X search-forward '%%'"
+bind -T copy-mode-vi ? command-prompt -p "?" "send -X search-backward '%%'"
+bind -T copy-mode-vi n send -X search-again
+bind -T copy-mode-vi N send -X search-reverse
 
-# Arrows in copy-mode
-bind-key -T copy-mode-vi Up    send -X cursor-up
-bind-key -T copy-mode-vi Down  send -X cursor-down
-bind-key -T copy-mode-vi Left  send -X cursor-left
-bind-key -T copy-mode-vi Right send -X cursor-right
-
-# Platform-specific clipboard copy on y
+# System clipboard (platform-specific)
 if-shell 'uname | grep -qi darwin' \
-  "bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel 'pbcopy'" \
-  "bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel 'xclip -in -selection clipboard'"
+  "bind -T copy-mode-vi y send -X copy-pipe-and-cancel 'pbcopy'" \
+  "bind -T copy-mode-vi y send -X copy-pipe-and-cancel 'xclip -in -selection clipboard'"
 
-# # Super fast pane movement (no prefix)
-# bind -n M-n select-pane -L   # Alt+h -> left pane
-# bind -n M-i select-pane -D   # Alt+j -> down pane
-# bind -n M-u select-pane -U   # Alt+k -> up pane
-# bind -n M-e select-pane -R   # Alt+l -> right pane
+# Paste
+bind p paste-buffer
+bind P choose-buffer
 
-##### Fancy bindings (sessions, panes, popups) #################################
+#----------------------------------------------------------------------------
+# Status Line
+#----------------------------------------------------------------------------
 
-# Toggle to last session or next, then kill current; fallback to kill-session
-bind-key t run-shell '(tmux switch-client -l || tmux switch-client -n) && tmux kill-session -t \"#S\" || tmux kill-session'
+set -g status-interval 5
+set -g status-position bottom
+set -g status-justify left
+set -g status-style "bg=default,fg=white"
 
-# Join pane from another target (horizontal)
-bind-key J command-prompt -p "join pane from: " "join-pane -h -s '%%'"
-
-# Swap panes visually
-bind-key s display-panes \; command-prompt -p "pane #: " "swap-pane -t '%%'"
-
-# Popup: attach workspace (tat)
-bind C-o display-popup -E "$HOME/.bin/tat.sh"
-
-# Popup: restart work apps (guard these scripts yourself as needed)
-bind p display-popup -E "$HOME/projects/work/script/restart-app people"
-bind f display-popup -E "$HOME/projects/work/script/restart-app 'File Search'"
-
-
-##### Theme & status line ######################################################
-
-# Colors
-set -gq @color_status_text "colour245"
-set -gq @color_window_off_status_bg "colour238"
-set -gq @color_light "white"
-set -gq @color_dark "colour232"
-set -gq @color_window_off_status_current_bg "colour254"
-
-set -g status-style "bg=default,fg=#{@color_light}"
-set -g window-status-current-style "bg=default,fg=magenta"
-set -g pane-border-style "fg=#{@color_light}"
-set -g pane-active-border-style "fg=#{@color_status_text},bg=default"
-set -g mode-style "fg=#{@color_light},bold"
-
-set -g status-interval 60
+# Left: session name
 set -g status-left-length 30
+set -g status-left "#[fg=cyan,bold]#S #[fg=white]| "
 
-# Git branch in status-left (safe if script missing)
-set -g status-left '#[fg=green]#([ -x "$HOME/.bin/tmux-git-branch.sh" ] && "$HOME/.bin/tmux-git-branch.sh" #{pane_current_path}) #[default]'
+# Right: git branch, host, time
+set -g status-right-length 80
+set -g status-right "#[fg=yellow]#(cd #{pane_current_path} && git branch --show-current 2>/dev/null)#[default] #[fg=blue]#H#[default] #[fg=magenta]%H:%M#[default]"
 
-# Indicator for "keys off" mode
-set -gq @color_window_off_indicator "colour196"
+# Window format
+setw -g window-status-format " #I:#W "
+setw -g window-status-current-format "#[fg=cyan,bold] #I:#W* "
+setw -g window-status-separator ""
 
-# Status-right (guard acpi so it doesn't spam errors if missing)
-set-option -g status-right "#(hostname) #[fg=red,bold]@#[fg=cyan] -> #[fg=blue,bold]#S#[default] #[fg=magenta]%R %h-%d #(command -v acpi >/dev/null 2>&1 && acpi | cut -d ',' -f2)"
+# Pane borders
+set -g pane-border-style "fg=colour238"
+set -g pane-active-border-style "fg=cyan"
 
-# Window/pane title
-set-option -g set-titles on
-set-option -g set-titles-string '#H:#S.#I.#P #W #T'
+# Messages
+set -g message-style "bg=default,fg=yellow"
 
-
-##### Keys-off mode toggle #####################################################
+#----------------------------------------------------------------------------
+# Keys-off Mode (for nested tmux)
+#----------------------------------------------------------------------------
 
 bind k \
-  set prefix None \; \
-  set key-table off \; \
-  set status-style "fg=#{@color_status_text},bg=#{@color_window_off_status_bg}" \; \
-  set window-status-current-format "#[fg=#{@color_window_off_status_bg},bg=#{@color_window_off_status_current_bg}]$separator_powerline_right#[default] #I:#W# #[fg=#{@color_window_off_status_current_bg},bg=#{@color_window_off_status_bg}]$separator_powerline_right#[default]" \; \
-  set window-status-current-style "fg=#{@color_dark},bold,bg=#{@color_window_off_status_current_bg}" \; \
-  if -F '#{pane_in_mode}' 'send-keys -X cancel' \; \
+  set prefix None \;\
+  set key-table off \;\
+  set status-style "bg=colour235,fg=colour245" \;\
   refresh-client -S
 
 bind -T off k \
-  set -u prefix \; \
-  set -u key-table \; \
-  set -u status-style \; \
-  set -u window-status-current-style \; \
-  set -u window-status-current-format \; \
+  set -u prefix \;\
+  set -u key-table \;\
+  set -u status-style \;\
   refresh-client -S
 
+#----------------------------------------------------------------------------
+# Popups & Tools
+#----------------------------------------------------------------------------
 
-##### Plugins ##################################################################
+# Lazygit
+bind g display-popup -E -w 90% -h 90% -d "#{pane_current_path}" "lazygit"
+
+# Floating terminal
+bind ` display-popup -E -w 80% -h 80% -d "#{pane_current_path}"
+
+#----------------------------------------------------------------------------
+# Plugins
+#----------------------------------------------------------------------------
 
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-continuum'
 
-set -g @continuum-restore 'on'
+# Resurrect settings
 set -g @resurrect-capture-pane-contents 'on'
+
+# Continuum settings
+set -g @continuum-restore 'on'
 set -g @continuum-save-interval '15'
 
+# Initialize TPM (keep at bottom)
 run-shell '~/.tmux/plugins/tpm/tpm'

--- a/.zshrc
+++ b/.zshrc
@@ -50,6 +50,9 @@ export PATH="$BUN_INSTALL/bin:$PATH"
 # Starship
 eval "$(starship init zsh)"
 
+# Zoxide (smart cd)
+command -v zoxide &>/dev/null && eval "$(zoxide init zsh)"
+
 # Kanata
 alias kanata-restart="sudo launchctl unload /Library/LaunchDaemons/com.custom.kanata.plist && sudo launchctl load /Library/LaunchDaemons/com.custom.kanata.plist"
 alias kanata-log="cat /tmp/kanata.out /tmp/kanata.err"
@@ -57,12 +60,10 @@ alias kanata-log="cat /tmp/kanata.out /tmp/kanata.err"
 export BUN_INSTALL="yes"
 export PATH="$BUN_INSTALL/bin:$PATH"
 
-# bun
-export BUN_INSTALL="yes"
-export PATH="$BUN_INSTALL/bin:$PATH"
-
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+
+export KUBECONFIG=/Users/edd/projects/kube/kubeconfig.local
 
 . "$HOME/.local/bin/env"

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,167 @@ cd ~/projects/dotfiles && ./setup.sh
 
 > Handles GitHub auth, SSH keys, and symlinks via [GNU Stow](https://www.gnu.org/software/stow/)
 
+---
+
+## 🖥️ Tmux Workflow
+
+A streamlined tmux workflow with fuzzy finding, project templates, and smart navigation.
+
+### Dependencies
+
+Installed automatically via setup scripts:
+
+| Package | Purpose |
+|---------|---------|
+| `tmux` | Terminal multiplexer |
+| `fzf` | Fuzzy finder |
+| `zoxide` | Smart directory jumping (frecency) |
+| `bat` | Syntax-highlighted previews |
+| `tree` | Directory tree display |
+| `jq` | JSON parsing (package.json scripts) |
+| `lazygit` | Git TUI |
+
+### Key Bindings
+
+Prefix is `Ctrl+Space`.
+
+#### Navigation
+
+| Binding | Action |
+|---------|--------|
+| `C-Space C-o` | **Project picker** - browse ~/projects with preview |
+| `C-Space C-n` | **Tmux navigator** - fuzzy search sessions/windows/panes |
+| `C-Space C-s` | Session tree (built-in) |
+| `C-Space g` | Lazygit popup |
+| `` C-Space ` `` | Floating terminal |
+
+#### Panes
+
+| Binding | Action |
+|---------|--------|
+| `C-Space v` | Split vertical (right) |
+| `C-Space s` | Split horizontal (below) |
+| `Arrow keys` | Navigate panes |
+| `Shift+Arrows` | Resize panes |
+| `C-Space z` | Toggle zoom |
+| `C-Space q` | Kill pane (with confirm) |
+| `C-Space S` | Swap panes |
+| `C-Space J` | Join pane from another window |
+
+#### Windows
+
+| Binding | Action |
+|---------|--------|
+| `C-Space w` | New window |
+| `C-Space r` | Rename window |
+| `C-Space 1-5` | Jump to window 1-5 |
+| `C-Space [` | Previous window |
+| `C-Space ]` | Next window |
+| `C-Space <` | Move window left |
+| `C-Space >` | Move window right |
+
+#### Sessions
+
+| Binding | Action |
+|---------|--------|
+| `C-Space $` | Rename session |
+| `C-Space t` | Kill session & switch to next |
+
+#### Copy Mode (vi-style)
+
+| Binding | Action |
+|---------|--------|
+| `C-Space Space` | Enter copy mode |
+| `v` | Begin selection |
+| `C-v` | Rectangle selection |
+| `y` | Copy to system clipboard |
+| `/` | Search forward |
+| `?` | Search backward |
+| `C-Space p` | Paste |
+| `C-Space P` | Choose buffer |
+
+#### Special
+
+| Binding | Action |
+|---------|--------|
+| `C-Space R` | Reload config |
+| `C-Space k` | Toggle keys-off mode (for nested tmux) |
+
+### Scripts
+
+#### Project Picker (`C-Space C-o`)
+
+```
+~/.bin/tat.sh
+```
+
+- Lists all directories in `~/projects`
+- Sorted by **zoxide frecency** (most used first)
+- Shows `[*]` indicator for active sessions
+- Preview pane shows: git status, project type, README
+
+#### Tmux Navigator (`C-Space C-n`)
+
+```
+~/.bin/tmux-nav.sh
+```
+
+Unified fuzzy finder for all tmux objects. Use symbol prefixes to filter:
+
+| Prefix | Shows |
+|--------|-------|
+| `@` | Sessions only |
+| `#` | Windows only |
+| `:` | Panes only |
+| (none) | Everything |
+
+Example: Type `@work` to filter sessions containing "work".
+
+#### Session Templates
+
+```
+~/.bin/tat-template.sh
+```
+
+Auto-detects project type and creates appropriate layout:
+
+| Detected By | Template | Windows |
+|-------------|----------|---------|
+| `package.json` | Node.js | editor+shell, server, git |
+| `Cargo.toml` | Rust | editor+shell, git |
+| `go.mod` | Go | editor+shell, git |
+| `pyproject.toml` | Python | editor+shell (venv), git |
+| `cluster/` + `Makefile` | Kubernetes | editor, k9s, git |
+| (default) | Simple | single pane |
+
+Override with `.tmux-template` file in project root containing template name.
+
+### Configuration Files
+
+| File | Purpose |
+|------|---------|
+| `~/.tmux.conf` | Main tmux configuration |
+| `~/.bin/tat.sh` | Project picker script |
+| `~/.bin/tat-preview.sh` | fzf preview for projects |
+| `~/.bin/tat-template.sh` | Session template logic |
+| `~/.bin/tmux-nav.sh` | Unified tmux navigator |
+
+### Plugins
+
+Managed via [TPM](https://github.com/tmux-plugins/tpm):
+
+- **tmux-resurrect** - Save/restore sessions across restarts
+- **tmux-continuum** - Auto-save every 15 minutes, auto-restore on start
+
+Install plugins after setup:
+
+```bash
+# Inside tmux
+C-Space I
+```
+
+---
+
 ## 🔗 Related
 
 | Platform | Repository |


### PR DESCRIPTION
## Summary
- Create shared library `tmux-lib.sh` to eliminate duplicate code across tmux scripts
- Extract common utilities: PATH setup, tmux/fzf detection, project type detection, bare repo resolution
- Consolidate identical `rust`/`go` templates into shared `apply_base_layout` function
- Net reduction of ~71 lines of duplicated code

## Files Changed
- `.bin/tmux-lib.sh` (new) - shared utilities
- `.bin/tat.sh` - uses library
- `.bin/tat-preview.sh` - uses library
- `.bin/tat-template.sh` - uses library + simplified templates
- `.bin/tmux-nav.sh` - uses library + removed redundant function

## Test plan
- [ ] Run `tat` to select and create project sessions
- [ ] Run `tmux-nav` to navigate between sessions/windows/panes
- [ ] Verify preview displays correctly in fzf
- [ ] Test template detection for different project types (node, rust, go, python)