### PR TITLE
feat: add claude code installation to all setup scripts

### DIFF
--- a/.bin/setup/arch.sh
+++ b/.bin/setup/arch.sh
@@ -69,6 +69,7 @@ setup_arch() {
     install_arch_specific_packages
 
     install_lazygit
+    install_claude_code
     setup_python
     setup_symlinks
     add_kanatakeyboardprev

--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -171,6 +171,16 @@ install_starship() {
     fi
 }
 
+install_claude_code() {
+    if command -v claude &> /dev/null; then
+        echo "Claude Code is already installed."
+        return 0
+    fi
+
+    echo "Installing Claude Code..."
+    curl -fsSL https://claude.ai/install.sh | bash
+}
+
 install_rust() {
     if [[ $CODESPACES == "true" ]]; then
         echo "In a GitHub Codespace environment, skipping Rust installation."

--- a/.bin/setup/mac.sh
+++ b/.bin/setup/mac.sh
@@ -188,6 +188,7 @@ setup_mac() {
     install_brew_packages
     install_brew_casks
     install_lazygit
+    install_claude_code
     setup_mac_python
     setup_symlinks
     setup_mac_security

--- a/.bin/setup/ubuntu.sh
+++ b/.bin/setup/ubuntu.sh
@@ -65,6 +65,7 @@ setup_ubuntu() {
         install_nvm
     fi
     install_lazygit
+    install_claude_code
     setup_python
     setup_symlinks
 }
@@ -72,6 +73,7 @@ setup_ubuntu() {
 setup_codespace() {
     update_system
     install_common_packages
+    install_claude_code
     setup_python
     setup_symlinks
 }


### PR DESCRIPTION
## Summary
- Add `install_claude_code` function to common.sh
- Call it from all setup scripts (macOS, Ubuntu, Arch, Codespaces)
- Uses official installer: `curl -fsSL https://claude.ai/install.sh | bash`

## Test plan
- [x] Run setup script on macOS
- [ ] Verify `claude` command is available after installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)