### PR TITLE
feat: improve WSL setup and ensure tmux 3.2+

### DIFF
--- a/.bin/setup/arch.sh
+++ b/.bin/setup/arch.sh
@@ -89,6 +89,7 @@ setup_arch() {
     install_yay
     install_nvm
     install_common_packages_arch
+    ensure_tmux_version
     install_arch_specific_packages
 
     install_lazygit

--- a/.bin/setup/ubuntu.sh
+++ b/.bin/setup/ubuntu.sh
@@ -74,6 +74,7 @@ clean_unneeded_software() {
 setup_ubuntu() {
     update_system
     install_common_packages
+    ensure_tmux_version
     install_ubuntu_specific_packages
 
     if [[ $CODESPACES != "true" ]]; then
@@ -88,6 +89,7 @@ setup_ubuntu() {
 setup_codespace() {
     update_system
     install_common_packages
+    ensure_tmux_version
     install_claude_code
     setup_python
     setup_symlinks


### PR DESCRIPTION
## Summary
- Skip cloning infrastructure repos on WSL (kube-homelab, blog-2026, tracker, growatt_exporter, byte_s, bash, eduuh-blog-template, life)
- Skip talosctl installation on WSL (should be installed on Windows host)
- Add `ensure_tmux_version` function to build tmux from source if version < 3.2 (required for display-popup feature)

## Test plan
- [ ] Test setup on Ubuntu/Codespaces to verify tmux version check works
- [ ] Test setup on WSL to verify repos and talosctl are skipped
- [ ] Test setup on macOS to verify no changes in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)