### PR TITLE
Add branch-notes: tmux-integrated note system

### DIFF
--- a/.bin/bn
+++ b/.bin/bn
@@ -1,0 +1,1 @@
+/Users/edd/.bin/branch-note.sh

--- a/.bin/bn-investigation-files.sh
+++ b/.bin/bn-investigation-files.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env zsh
+# bn-investigation-files.sh - List investigation files for /get-context skill
+note_dir=$(bn --path 2>/dev/null) || { echo "No investigation files."; exit 0; }
+files=("$note_dir"/*.md(N))
+found=false
+for f in "${files[@]}"; do
+    [[ "$(basename "$f")" == "note.md" ]] && continue
+    found=true
+    echo "### $(basename "$f")"
+    echo '```'
+    cat "$f"
+    echo '```'
+    echo
+done
+$found || echo "No investigation files."

--- a/.bin/branch-note-status.sh
+++ b/.bin/branch-note-status.sh
@@ -15,4 +15,4 @@ note_status=$(sed -n '/^---$/,/^---$/{ /^status:/s/^status: *//p; }' "$note")
 [[ "$note_status" == "closed" ]] && exit 0
 
 count=$(grep -c '^\- \[ \]' "$note" 2>/dev/null)
-(( count > 0 )) && echo " [$count]"
+(( count > 0 )) && echo " TODO[$count]"

--- a/.bin/branch-note-status.sh
+++ b/.bin/branch-note-status.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env zsh
+# branch-note-status.sh - Todo count for tmux status bar
+# Output e.g. " [3]" if there are open todos, nothing otherwise.
+# Called every status-interval (5s) — must be fast and silent on failure.
+
+source "$HOME/.bin/tmux-lib.sh"
+
+resolve_note_context "${1:-$(pwd)}" || exit 0
+
+note="$HOME/projects/personal-notes/branch-notes/$NOTE_REPO/$NOTE_BRANCH/note.md"
+[[ -f "$note" ]] || exit 0
+
+count=$(grep -c '^\- \[ \]' "$note" 2>/dev/null)
+(( count > 0 )) && echo " [$count]"

--- a/.bin/branch-note-status.sh
+++ b/.bin/branch-note-status.sh
@@ -11,8 +11,8 @@ note="$HOME/projects/personal-notes/branch-notes/$NOTE_REPO/$NOTE_BRANCH/note.md
 [[ -f "$note" ]] || exit 0
 
 # Skip closed notes
-status=$(sed -n '/^---$/,/^---$/{ /^status:/s/^status: *//p; }' "$note")
-[[ "$status" == "closed" ]] && exit 0
+note_status=$(sed -n '/^---$/,/^---$/{ /^status:/s/^status: *//p; }' "$note")
+[[ "$note_status" == "closed" ]] && exit 0
 
 count=$(grep -c '^\- \[ \]' "$note" 2>/dev/null)
 (( count > 0 )) && echo " [$count]"

--- a/.bin/branch-note-status.sh
+++ b/.bin/branch-note-status.sh
@@ -10,5 +10,9 @@ resolve_note_context "${1:-$(pwd)}" || exit 0
 note="$HOME/projects/personal-notes/branch-notes/$NOTE_REPO/$NOTE_BRANCH/note.md"
 [[ -f "$note" ]] || exit 0
 
+# Skip closed notes
+status=$(sed -n '/^---$/,/^---$/{ /^status:/s/^status: *//p; }' "$note")
+[[ "$status" == "closed" ]] && exit 0
+
 count=$(grep -c '^\- \[ \]' "$note" 2>/dev/null)
 (( count > 0 )) && echo " [$count]"

--- a/.bin/branch-note.sh
+++ b/.bin/branch-note.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env zsh
+# branch-note.sh - Universal branch note resolver
+# Usage:
+#   branch-note                          # Ensure note exists, print dir path
+#   branch-note --path                   # Print note dir path only (no create)
+#   branch-note --cat [file]             # Print note.md contents (or specific file)
+#   branch-note --edit [file]            # Open note.md in $EDITOR (or specific file)
+#   branch-note add <section> <text>     # Add line to section
+#   branch-note list                     # List all notes across repos
+#   branch-note summary                  # Dashboard: open todos, blockers, per-branch detail
+
+source "$HOME/.bin/tmux-lib.sh"
+
+NOTES_DIR="$HOME/projects/personal-notes/branch-notes"
+
+# Create note from template if it doesn't exist
+ensure_note() {
+    local note_dir="$NOTES_DIR/$NOTE_REPO/$NOTE_BRANCH"
+    local note_file="$note_dir/note.md"
+    if [[ ! -f "$note_file" ]]; then
+        mkdir -p "$note_dir"
+        cat > "$note_file" << EOF
+---
+repo: $NOTE_REPO
+branch: $NOTE_BRANCH
+created: $(date +%Y-%m-%d)
+type:
+collaborators: []
+---
+
+# $NOTE_REPO / $NOTE_BRANCH
+
+## Goal
+
+
+## Todos
+- [ ]
+
+## Blockers
+-
+
+## Decisions
+-
+
+## To Research
+-
+
+## Collaboration
+-
+
+## To Ask
+-
+
+---
+## Windows
+EOF
+    fi
+}
+
+# Map short section name to heading
+section_heading() {
+    case "$1" in
+        todo|todos)         echo "## Todos" ;;
+        blocker|blockers)   echo "## Blockers" ;;
+        decision|decisions) echo "## Decisions" ;;
+        research)           echo "## To Research" ;;
+        collab)             echo "## Collaboration" ;;
+        ask)                echo "## To Ask" ;;
+        *) echo "" ;;
+    esac
+}
+
+# Format line based on section type
+format_line() {
+    local section="$1" text="$2"
+    case "$section" in
+        todo|todos) echo "- [ ] $text" ;;
+        *)          echo "- $text" ;;
+    esac
+}
+
+# Insert a line into the correct section of a note
+insert_into_section() {
+    local note_file="$1" heading="$2" line="$3"
+
+    local heading_line
+    heading_line=$(grep -n "^${heading}$" "$note_file" | head -1 | cut -d: -f1)
+    [[ -z "$heading_line" ]] && { echo "Section '$heading' not found in note" >&2; return 1; }
+
+    local after_heading=$((heading_line + 1))
+    local next_heading_rel
+    next_heading_rel=$(tail -n +$after_heading "$note_file" | grep -n '^## \|^---$' | head -1 | cut -d: -f1)
+
+    if [[ -n "$next_heading_rel" ]]; then
+        local insert_at=$((heading_line + next_heading_rel - 1))
+        # Insert blank line + content before the next heading
+        perl -i -pe "print \"${line}\n\" if \$. == ${insert_at}" "$note_file"
+    else
+        echo "$line" >> "$note_file"
+    fi
+}
+
+# Add a line to a section
+cmd_add() {
+    local section="$1"
+    [[ -z "$section" ]] && { echo "Usage: branch-note add <section> <text>" >&2; exit 1; }
+    shift
+    local text="$*"
+    [[ -z "$text" ]] && { echo "Usage: branch-note add <section> <text>" >&2; exit 1; }
+
+    local heading
+    heading=$(section_heading "$section")
+    [[ -z "$heading" ]] && { echo "Unknown section: $section (use: todo, blocker, decision, research, collab, ask)" >&2; exit 1; }
+
+    resolve_note_context "$(pwd)" || { echo "Not in a git repo" >&2; exit 1; }
+    ensure_note
+
+    local note_file="$NOTES_DIR/$NOTE_REPO/$NOTE_BRANCH/note.md"
+    local line
+    line=$(format_line "$section" "$text")
+
+    insert_into_section "$note_file" "$heading" "$line"
+    echo "Added to ${heading#\#\# }: $text"
+}
+
+# List all notes across repos
+cmd_list() {
+    [[ ! -d "$NOTES_DIR" ]] && { echo "No branch notes found"; exit 0; }
+
+    local found=false
+    for note_file in "$NOTES_DIR"/*/*/note.md(N); do
+        found=true
+        local note_dir=$(dirname "$note_file")
+        local branch=$(basename "$note_dir")
+        local repo=$(basename "$(dirname "$note_dir")")
+
+        local type=""
+        type=$(sed -n '/^---$/,/^---$/{ /^type:/s/^type: *//p; }' "$note_file")
+        [[ -z "$type" ]] && type="-"
+
+        local todos=0
+        todos=$(grep -c '^\- \[ \]' "$note_file" 2>/dev/null || true)
+
+        local created=""
+        created=$(sed -n '/^---$/,/^---$/{ /^created:/s/^created: *//p; }' "$note_file")
+
+        printf "%-30s %-12s %d todos  %s\n" "$repo/$branch" "$type" "$todos" "$created"
+    done
+
+    $found || echo "No branch notes found"
+}
+
+# Summary dashboard
+cmd_summary() {
+    [[ ! -d "$NOTES_DIR" ]] && { echo "No branch notes found"; exit 0; }
+
+    local total_todos=0
+    local total_blockers=0
+    local details=""
+    local found=false
+
+    for note_file in "$NOTES_DIR"/*/*/note.md(N); do
+        found=true
+        local note_dir=$(dirname "$note_file")
+        local branch=$(basename "$note_dir")
+        local repo=$(basename "$(dirname "$note_dir")")
+
+        local type=""
+        type=$(sed -n '/^---$/,/^---$/{ /^type:/s/^type: *//p; }' "$note_file")
+        [[ -z "$type" ]] && type="-"
+
+        local todos=0
+        todos=$(grep -c '^\- \[ \]' "$note_file" 2>/dev/null || true)
+        total_todos=$((total_todos + todos))
+
+        # Count non-empty blocker lines
+        local blockers=0
+        blockers=$(awk '/^## Blockers$/{found=1; next} /^## |^---$/{found=0} found && /^- ./' "$note_file" | wc -l | tr -d ' ')
+        total_blockers=$((total_blockers + blockers))
+
+        # Build per-branch detail
+        local header="\n$repo/$branch ($type, $todos todos"
+        (( blockers > 0 )) && header="$header, $blockers blockers"
+        header="$header)"
+
+        local items=""
+        # Collect open todos
+        while IFS= read -r line; do
+            [[ -n "$line" ]] && items="$items\n  ${line#- }"
+        done <<< "$(grep '^\- \[ \]' "$note_file" 2>/dev/null)"
+
+        # Collect blockers
+        while IFS= read -r line; do
+            [[ -n "$line" ]] && items="$items\n  [!] ${line#- }"
+        done <<< "$(awk '/^## Blockers$/{found=1; next} /^## |^---$/{found=0} found && /^- ./' "$note_file" 2>/dev/null)"
+
+        if (( todos > 0 )) || (( blockers > 0 )); then
+            details="$details$header$items"
+        fi
+    done
+
+    if $found; then
+        echo "Open todos across all branches: $total_todos"
+        echo "Blockers: $total_blockers"
+        [[ -n "$details" ]] && print "$details"
+    else
+        echo "No branch notes found"
+    fi
+}
+
+# Main
+case "${1:-}" in
+    --path)
+        resolve_note_context "$(pwd)" || { echo "Not in a git repo" >&2; exit 1; }
+        echo "$NOTES_DIR/$NOTE_REPO/$NOTE_BRANCH"
+        ;;
+    --cat)
+        resolve_note_context "$(pwd)" || { echo "Not in a git repo" >&2; exit 1; }
+        local file="${2:-note.md}"
+        cat "$NOTES_DIR/$NOTE_REPO/$NOTE_BRANCH/$file"
+        ;;
+    --edit)
+        resolve_note_context "$(pwd)" || { echo "Not in a git repo" >&2; exit 1; }
+        ensure_note
+        local file="${2:-note.md}"
+        ${EDITOR:-nvim} "$NOTES_DIR/$NOTE_REPO/$NOTE_BRANCH/$file"
+        ;;
+    add)
+        shift
+        cmd_add "$@"
+        ;;
+    list)
+        cmd_list
+        ;;
+    summary)
+        cmd_summary
+        ;;
+    -h|--help|help)
+        cat << 'HELPEOF'
+Usage: branch-note [command]
+
+Commands:
+  (none)                          Ensure note exists, print dir path
+  --path                          Print note dir path (no create)
+  --cat [file]                    Print note.md (or specific file)
+  --edit [file]                   Open note in $EDITOR
+  add <section> <text>            Add line to section
+  list                            List all notes across repos
+  summary                         Dashboard of active work
+
+Sections: todo, blocker, decision, research, collab, ask
+HELPEOF
+        ;;
+    "")
+        resolve_note_context "$(pwd)" || { echo "Not in a git repo" >&2; exit 1; }
+        ensure_note
+        echo "$NOTES_DIR/$NOTE_REPO/$NOTE_BRANCH"
+        ;;
+    *)
+        echo "Unknown command: $1" >&2
+        exit 1
+        ;;
+esac

--- a/.bin/tmux-lib.sh
+++ b/.bin/tmux-lib.sh
@@ -79,3 +79,20 @@ apply_base_layout() {
     $TMUX_CMD select-window -t "$name:editor"
     $TMUX_CMD select-pane -t "$name:editor.0"
 }
+
+# Resolve repo name and branch from a directory path
+# Sets: NOTE_REPO, NOTE_BRANCH (slashes sanitized to dashes)
+resolve_note_context() {
+    local dir="$1"
+    if [[ "$dir" == "$WORKTREE_DIR"/* ]]; then
+        local rel="${dir#$WORKTREE_DIR/}"
+        NOTE_REPO="${rel%%/*}"
+        NOTE_BRANCH=$(git -C "$dir" branch --show-current 2>/dev/null)
+    else
+        NOTE_REPO=$(basename "$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null)")
+        NOTE_BRANCH=$(git -C "$dir" branch --show-current 2>/dev/null)
+    fi
+    [[ -z "$NOTE_REPO" || -z "$NOTE_BRANCH" ]] && return 1
+    NOTE_BRANCH="${NOTE_BRANCH//\//-}"
+    return 0
+}

--- a/.bin/tmux-note-add.sh
+++ b/.bin/tmux-note-add.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env zsh
+# tmux-note-add.sh - Quick-add to branch note via fzf section picker
+# Called via: bind N display-popup -E ... "$HOME/.bin/tmux-note-add.sh '#{pane_current_path}'"
+
+source "$HOME/.bin/tmux-lib.sh"
+require_fzf
+
+# cd to pane path so branch-note.sh subcommands resolve correctly
+pane_path="${1:-$(pwd)}"
+cd "$pane_path" 2>/dev/null || { echo "Invalid path: $pane_path"; read -sk1; exit 1; }
+resolve_note_context "$pane_path" || { echo "Not in a git repo"; read -sk1; exit 1; }
+
+# Ensure note exists
+"$HOME/.bin/branch-note.sh" >/dev/null
+
+# fzf section picker
+section=$(printf "Todos\nBlockers\nDecisions\nTo Research\nCollaboration\nTo Ask" | $FZF_CMD --prompt="Section: " --height=8 --reverse)
+[[ -z "$section" ]] && exit 0
+
+# Map display name to add command name
+case "$section" in
+    Todos)         cmd_section="todo" ;;
+    Blockers)      cmd_section="blocker" ;;
+    Decisions)     cmd_section="decision" ;;
+    "To Research") cmd_section="research" ;;
+    Collaboration) cmd_section="collab" ;;
+    "To Ask")      cmd_section="ask" ;;
+esac
+
+# Prompt for text
+window_name=$(tmux display-message -p '#{window_name}' 2>/dev/null)
+printf "> "
+read -r "input"
+[[ -z "$input" ]] && exit 0
+
+# Add context tag and insert
+[[ -n "$window_name" ]] && input="$input *($window_name)*"
+"$HOME/.bin/branch-note.sh" add "$cmd_section" "$input"

--- a/.bin/tmux-note-sync.sh
+++ b/.bin/tmux-note-sync.sh
@@ -19,9 +19,8 @@ note_file="$NOTES_DIR/$NOTE_REPO/$NOTE_BRANCH/note.md"
 [[ -f "$note_file" ]] || exit 0
 
 # Get current windows and append missing sections
-windows=($(tmux list-windows -F '#{window_name}' 2>/dev/null))
-for win in "${windows[@]}"; do
-    if ! grep -q "^### $win$" "$note_file" 2>/dev/null; then
+tmux list-windows -F '#{window_name}' 2>/dev/null | while IFS= read -r win; do
+    if ! grep -Fq "### $win" "$note_file" 2>/dev/null; then
         echo "" >> "$note_file"
         echo "### $win" >> "$note_file"
     fi

--- a/.bin/tmux-note-sync.sh
+++ b/.bin/tmux-note-sync.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env zsh
+# tmux-note-sync.sh - Sync tmux window names to branch note sections
+# Called by tmux hooks (after-new-window, window-renamed) via run-shell -b
+# Never auto-creates notes — only appends to existing ones.
+
+source "$HOME/.bin/tmux-lib.sh"
+
+NOTES_DIR="$HOME/projects/personal-notes/branch-notes"
+
+# Get active pane path from current session
+pane_path=$(tmux display-message -p '#{pane_current_path}' 2>/dev/null)
+[[ -z "$pane_path" ]] && exit 0
+
+# Resolve repo/branch
+resolve_note_context "$pane_path" || exit 0
+
+# Check if note exists — if not, exit silently (don't auto-create)
+note_file="$NOTES_DIR/$NOTE_REPO/$NOTE_BRANCH/note.md"
+[[ -f "$note_file" ]] || exit 0
+
+# Get current windows and append missing sections
+windows=($(tmux list-windows -F '#{window_name}' 2>/dev/null))
+for win in "${windows[@]}"; do
+    if ! grep -q "^### $win$" "$note_file" 2>/dev/null; then
+        echo "" >> "$note_file"
+        echo "### $win" >> "$note_file"
+    fi
+done

--- a/.bin/tmux-note.sh
+++ b/.bin/tmux-note.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env zsh
+# tmux-note.sh - Open branch note in tmux popup
+# Called via: bind n display-popup -E ... "$HOME/.bin/tmux-note.sh '#{pane_current_path}'"
+
+source "$HOME/.bin/tmux-lib.sh"
+
+NOTES_DIR="$HOME/projects/personal-notes/branch-notes"
+
+# cd to pane path so branch-note.sh subcommands resolve correctly
+pane_path="${1:-$(pwd)}"
+cd "$pane_path" 2>/dev/null || { echo "Invalid path: $pane_path"; read -sk1; exit 1; }
+resolve_note_context "$pane_path" || { echo "Not in a git repo"; read -sk1; exit 1; }
+
+# Ensure note exists (creates from template if needed)
+note_dir=$("$HOME/.bin/branch-note.sh")
+note_file="$note_dir/note.md"
+
+# Sync window sections
+windows=($(tmux list-windows -F '#{window_name}' 2>/dev/null))
+for win in "${windows[@]}"; do
+    if ! grep -q "^### $win$" "$note_file" 2>/dev/null; then
+        echo "" >> "$note_file"
+        echo "### $win" >> "$note_file"
+    fi
+done
+
+# Open in editor
+${EDITOR:-nvim} "$note_file"

--- a/.bin/tmux-note.sh
+++ b/.bin/tmux-note.sh
@@ -16,9 +16,8 @@ note_dir=$("$HOME/.bin/branch-note.sh")
 note_file="$note_dir/note.md"
 
 # Sync window sections
-windows=($(tmux list-windows -F '#{window_name}' 2>/dev/null))
-for win in "${windows[@]}"; do
-    if ! grep -q "^### $win$" "$note_file" 2>/dev/null; then
+tmux list-windows -F '#{window_name}' 2>/dev/null | while IFS= read -r win; do
+    if ! grep -Fq "### $win" "$note_file" 2>/dev/null; then
         echo "" >> "$note_file"
         echo "### $win" >> "$note_file"
     fi

--- a/.bin/tmux-wt.sh
+++ b/.bin/tmux-wt.sh
@@ -1,10 +1,22 @@
 #!/usr/bin/env zsh
 # tmux-wt.sh - Unified worktree manager popup (create/remove)
 # Bound to prefix+W in tmux
+# Usage: tmux-wt.sh [current_pane_path]
 
 source "$HOME/.bin/tmux-lib.sh"
 tmux_init
 require_fzf
+
+NOTES_DIR="$HOME/projects/personal-notes/branch-notes"
+CURRENT_PATH="${1:-}"
+
+# Auto-detect repo from current path (if inside a worktree)
+auto_detect_repo() {
+    if [[ -n "$CURRENT_PATH" && "$CURRENT_PATH" == "$WORKTREE_DIR"/* ]]; then
+        local rel="${CURRENT_PATH#$WORKTREE_DIR/}"
+        echo "${rel%%/*}"
+    fi
+}
 
 # Step 1: Action picker
 action=$(printf 'Create worktree\nRemove worktree' | $FZF_CMD --prompt="Action: " --reverse)
@@ -14,17 +26,25 @@ action=$(printf 'Create worktree\nRemove worktree' | $FZF_CMD --prompt="Action: 
 # Create worktree
 #============================================================================
 if [[ "$action" == "Create worktree" ]]; then
-    # 1. List bare repos → fzf picker
-    bare_repos=("$BARE_DIR"/*.git(N/))
-    [[ ${#bare_repos[@]} -eq 0 ]] && { echo "No bare repos found in $BARE_DIR"; read -sk1; exit 1; }
+    # Auto-detect repo or show picker
+    detected_repo=$(auto_detect_repo)
 
-    repo_names=()
-    for bare in "${bare_repos[@]}"; do
-        repo_names+=($(basename "$bare" .git))
-    done
+    if [[ -n "$detected_repo" && -d "$BARE_DIR/${detected_repo}.git" ]]; then
+        selected="$detected_repo"
+        echo "Repo: $selected (auto-detected)"
+    else
+        # List bare repos → fzf picker
+        bare_repos=("$BARE_DIR"/*.git(N/))
+        [[ ${#bare_repos[@]} -eq 0 ]] && { echo "No bare repos found in $BARE_DIR"; read -sk1; exit 1; }
 
-    selected=$(printf '%s\n' "${repo_names[@]}" | $FZF_CMD --prompt="Repo: " --reverse)
-    [[ -z "$selected" ]] && exit 0
+        repo_names=()
+        for bare in "${bare_repos[@]}"; do
+            repo_names+=($(basename "$bare" .git))
+        done
+
+        selected=$(printf '%s\n' "${repo_names[@]}" | $FZF_CMD --prompt="Repo: " --reverse)
+        [[ -z "$selected" ]] && exit 0
+    fi
 
     bare_repo="$BARE_DIR/${selected}.git"
 
@@ -59,9 +79,16 @@ if [[ "$action" == "Create worktree" ]]; then
         exit 1
     fi
 
+    # 4. Run build.sh if it exists for this repo
+    local build_sh="$NOTES_DIR/${selected}/main/build.sh"
+    if [[ -x "$build_sh" ]]; then
+        echo "Running build.sh..."
+        (cd "$worktree_path" && "$build_sh")
+    fi
+
     echo "Done!"
 
-    # 4. Open tmux session in new worktree
+    # 5. Open tmux session in new worktree
     session_name="${selected}/${sanitized}"
     "$HOME/.bin/tat-template.sh" "$session_name" "$worktree_path"
 
@@ -72,43 +99,31 @@ elif [[ "$action" == "Remove worktree" ]]; then
     removed=0
 
     while true; do
-        # 1. Gather worktrees from all bare repos
-        entries=()
+        # 1. Gather worktree display names (repo/branch) from all bare repos
+        names=()
         for bare in "$BARE_DIR"/*.git(N/); do
-            local repo_name=$(basename "$bare" .git)
-            local wt_lines=("${(@f)$(git --git-dir="$bare" worktree list --porcelain | grep '^worktree ')}")
+            repo_name=$(basename "$bare" .git)
+            wt_lines=("${(@f)$(git --git-dir="$bare" worktree list --porcelain | grep '^worktree ')}")
             for line in "${wt_lines[@]}"; do
-                local wt_path="${line#worktree }"
+                wt_path="${line#worktree }"
                 [[ "$wt_path" == "$BARE_DIR"/* ]] && continue
-                local branch_dir=$(basename "$wt_path")
-                # Skip main/master — these should never be removed
+                branch_dir=$(basename "$wt_path")
                 [[ "$branch_dir" == "main" || "$branch_dir" == "master" ]] && continue
-                entries+=("${repo_name}/${branch_dir}\t${wt_path}")
+                names+=("${repo_name}/${branch_dir}")
             done
         done
 
-        [[ ${#entries[@]} -eq 0 ]] && { echo "No worktrees found"; break; }
+        [[ ${#names[@]} -eq 0 ]] && { echo "No worktrees found"; break; }
 
-        # 2. Display in fzf picker
-        selected=$(printf '%s\n' "${entries[@]}" | cut -f1 | $FZF_CMD --prompt="Remove: " --reverse)
+        # 2. fzf picker
+        selected=$(printf '%s\n' "${names[@]}" | $FZF_CMD --prompt="Remove: " --reverse)
         [[ -z "$selected" ]] && break
 
-        # Find the full path for the selected entry
-        selected_path=""
-        for entry in "${entries[@]}"; do
-            local display="${entry%%$'\t'*}"
-            local path="${entry#*$'\t'}"
-            if [[ "$display" == "$selected" ]]; then
-                selected_path="$path"
-                break
-            fi
-        done
-
-        [[ -z "$selected_path" ]] && { echo "Error: could not resolve path"; break; }
-
-        # 3. Find the bare repo for this worktree
-        local repo_name="${selected%%/*}"
-        local bare_repo="$BARE_DIR/${repo_name}.git"
+        # 3. Derive paths from selection (repo/branch)
+        repo_name="${selected%%/*}"
+        branch_dir="${selected#*/}"
+        selected_path="$WORKTREE_DIR/${repo_name}/${branch_dir}"
+        bare_repo="$BARE_DIR/${repo_name}.git"
 
         if [[ ! -d "$bare_repo" ]]; then
             echo "Error: bare repo not found: $bare_repo"
@@ -124,8 +139,8 @@ elif [[ "$action" == "Remove worktree" ]]; then
         fi
 
         # 5. Clean up empty repo directory
-        local repo_dir=$(dirname "$selected_path")
-        if [[ "$repo_dir" == "$WORKTREE_DIR"/* ]] && [[ -d "$repo_dir" ]]; then
+        repo_dir="$WORKTREE_DIR/${repo_name}"
+        if [[ -d "$repo_dir" ]]; then
             rmdir "$repo_dir" 2>/dev/null || true
         fi
 

--- a/.bin/tmux-wt.sh
+++ b/.bin/tmux-wt.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env zsh
+# tmux-wt.sh - Unified worktree manager popup (create/remove)
+# Bound to prefix+W in tmux
+
+source "$HOME/.bin/tmux-lib.sh"
+tmux_init
+require_fzf
+
+# Step 1: Action picker
+action=$(printf 'Create worktree\nRemove worktree' | $FZF_CMD --prompt="Action: " --reverse)
+[[ -z "$action" ]] && exit 0
+
+#============================================================================
+# Create worktree
+#============================================================================
+if [[ "$action" == "Create worktree" ]]; then
+    # 1. List bare repos → fzf picker
+    bare_repos=("$BARE_DIR"/*.git(N/))
+    [[ ${#bare_repos[@]} -eq 0 ]] && { echo "No bare repos found in $BARE_DIR"; read -sk1; exit 1; }
+
+    repo_names=()
+    for bare in "${bare_repos[@]}"; do
+        repo_names+=($(basename "$bare" .git))
+    done
+
+    selected=$(printf '%s\n' "${repo_names[@]}" | $FZF_CMD --prompt="Repo: " --reverse)
+    [[ -z "$selected" ]] && exit 0
+
+    bare_repo="$BARE_DIR/${selected}.git"
+
+    # 2. Prompt for branch name
+    printf "Branch name: "
+    read -r branch_name
+    [[ -z "$branch_name" ]] && exit 0
+
+    sanitized=$(echo "$branch_name" | tr '/' '-')
+    worktree_path="$WORKTREE_DIR/${selected}/${sanitized}"
+
+    if [[ -d "$worktree_path" ]]; then
+        echo "Worktree already exists: $worktree_path"
+        read -sk1 "?Press any key..."
+        exit 0
+    fi
+
+    # 3. Fetch + reset main + create worktree
+    echo "Fetching origin..."
+    git --git-dir="$bare_repo" fetch origin
+
+    echo "Updating main → origin/main..."
+    git --git-dir="$bare_repo" branch -f main origin/main 2>/dev/null
+
+    echo "Creating worktree: $worktree_path"
+    mkdir -p "$WORKTREE_DIR/${selected}"
+    git --git-dir="$bare_repo" worktree add -b "$branch_name" "$worktree_path" main
+
+    if [[ $? -ne 0 ]]; then
+        echo "Failed to create worktree"
+        read -sk1 "?Press any key..."
+        exit 1
+    fi
+
+    echo "Done!"
+
+    # 4. Open tmux session in new worktree
+    session_name="${selected}/${sanitized}"
+    "$HOME/.bin/tat-template.sh" "$session_name" "$worktree_path"
+
+#============================================================================
+# Remove worktree
+#============================================================================
+elif [[ "$action" == "Remove worktree" ]]; then
+    # 1. Gather worktrees from all bare repos
+    typeset -A wt_display_to_path  # display name → full path
+    display_names=()
+
+    for bare in "$BARE_DIR"/*.git(N/); do
+        local repo_name=$(basename "$bare" .git)
+
+        # Get worktree paths (skip the bare repo entry itself)
+        git --git-dir="$bare" worktree list --porcelain | while IFS= read -r line; do
+            if [[ "$line" == worktree\ * ]]; then
+                local wt_path="${line#worktree }"
+                # Skip bare repo entries
+                [[ "$wt_path" == "$BARE_DIR"/* ]] && continue
+                # Derive display name as repo/branch from path
+                local branch_dir=$(basename "$wt_path")
+                local display="${repo_name}/${branch_dir}"
+                echo "${display}\t${wt_path}"
+            fi
+        done
+    done | while IFS=$'\t' read -r display path; do
+        display_names+=("$display")
+        wt_display_to_path[$display]="$path"
+    done
+
+    # Rebuild from subshell — pipe loses variable scope
+    entries=()
+    for bare in "$BARE_DIR"/*.git(N/); do
+        local repo_name=$(basename "$bare" .git)
+        local wt_lines=("${(@f)$(git --git-dir="$bare" worktree list --porcelain | grep '^worktree ')}")
+        for line in "${wt_lines[@]}"; do
+            local wt_path="${line#worktree }"
+            [[ "$wt_path" == "$BARE_DIR"/* ]] && continue
+            local branch_dir=$(basename "$wt_path")
+            entries+=("${repo_name}/${branch_dir}\t${wt_path}")
+        done
+    done
+
+    [[ ${#entries[@]} -eq 0 ]] && { echo "No worktrees found"; read -sk1; exit 0; }
+
+    # 2. Display in fzf picker
+    selected=$(printf '%s\n' "${entries[@]}" | cut -f1 | $FZF_CMD --prompt="Remove: " --reverse)
+    [[ -z "$selected" ]] && exit 0
+
+    # Find the full path for the selected entry
+    selected_path=""
+    for entry in "${entries[@]}"; do
+        local display="${entry%%$'\t'*}"
+        local path="${entry#*$'\t'}"
+        if [[ "$display" == "$selected" ]]; then
+            selected_path="$path"
+            break
+        fi
+    done
+
+    [[ -z "$selected_path" ]] && { echo "Error: could not resolve path"; read -sk1; exit 1; }
+
+    # 3. Find the bare repo for this worktree
+    # Derive repo name from display (repo/branch → repo)
+    local repo_name="${selected%%/*}"
+    local bare_repo="$BARE_DIR/${repo_name}.git"
+
+    if [[ ! -d "$bare_repo" ]]; then
+        echo "Error: bare repo not found: $bare_repo"
+        read -sk1 "?Press any key..."
+        exit 1
+    fi
+
+    # 4. Remove worktree
+    echo "Removing worktree: $selected"
+    git --git-dir="$bare_repo" worktree remove "$selected_path"
+
+    if [[ $? -ne 0 ]]; then
+        echo "Failed to remove worktree"
+        read -sk1 "?Press any key..."
+        exit 1
+    fi
+
+    # 5. Clean up empty repo directory
+    local repo_dir=$(dirname "$selected_path")
+    if [[ "$repo_dir" == "$WORKTREE_DIR"/* ]] && [[ -d "$repo_dir" ]]; then
+        rmdir "$repo_dir" 2>/dev/null || true
+    fi
+
+    # 6. Kill tmux session if it exists
+    $TMUX_CMD kill-session -t "$selected" 2>/dev/null || true
+
+    # 7. Prune orphaned branch notes
+    "$HOME/.bin/branch-note.sh" prune
+
+    echo "Removed: $selected"
+fi

--- a/.bin/wt.sh
+++ b/.bin/wt.sh
@@ -317,6 +317,9 @@ cmd_remove() {
     fi
 
     echo -e "${GREEN}Removed worktree${NC}"
+
+    # Close any orphaned branch notes
+    "$HOME/.bin/branch-note.sh" prune
 }
 
 # Go to a worktree (for shell functions)

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -121,8 +121,9 @@ bind t run-shell '(tmux switch-client -l || tmux switch-client -n) && tmux kill-
 # Rename current session (. is easy to type, next to , for window)
 bind . command-prompt -p "Rename session:" "rename-session '%%'"
 
-# Rename any session (pick from list)
-bind n display-popup -E -w 70% -h 60% "$HOME/.bin/tmux-rename-session.sh"
+# Branch notes
+bind n display-popup -E -w 90% -h 90% -d "#{pane_current_path}" "$HOME/.bin/tmux-note.sh"
+bind N display-popup -E -w 50% -h 40% -d "#{pane_current_path}" "$HOME/.bin/tmux-note-add.sh"
 
 # Open matching repos in synchronized panes (prefix S)
 bind S command-prompt -p "Repo prefix:" "run-shell '$HOME/.bin/tmux-sync-repos.sh %%'"
@@ -177,9 +178,9 @@ set -g status-style "bg=default,fg=white"
 # Left: empty
 set -g status-left ""
 
-# Right: git branch
+# Right: git branch + todo count
 set -g status-right-length 80
-set -g status-right "#[fg=yellow]#(cd #{pane_current_path} && git branch --show-current 2>/dev/null)#[default]"
+set -g status-right "#[fg=yellow]#(cd #{pane_current_path} && git branch --show-current 2>/dev/null)#[fg=red]#($HOME/.bin/branch-note-status.sh '#{pane_current_path}')#[default]"
 
 # Window format
 setw -g window-status-format " #I:#W "
@@ -229,6 +230,10 @@ bind i if-shell '[ "$(tmux show -gqv @scratch)" = "on" ]' \
 
 # Voice input (macOS only)
 bind C-r display-popup -E -w 60% -h 40% "$HOME/.bin/voice"
+
+# Branch note: sync window sections on window create/rename
+set-hook -g after-new-window 'run-shell -b "$HOME/.bin/tmux-note-sync.sh"'
+set-hook -g window-renamed 'run-shell -b "$HOME/.bin/tmux-note-sync.sh"'
 
 #----------------------------------------------------------------------------
 # Plugins

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -122,7 +122,7 @@ bind t run-shell '(tmux switch-client -l || tmux switch-client -n) && tmux kill-
 bind . command-prompt -p "Rename session:" "rename-session '%%'"
 
 # Worktree manager (create/remove)
-bind W display-popup -E -w 60% -h 50% "$HOME/.bin/tmux-wt.sh"
+bind W display-popup -E -w 60% -h 50% "$HOME/.bin/tmux-wt.sh '#{pane_current_path}'"
 
 # Branch notes
 bind n display-popup -E -w 90% -h 90% -d "#{pane_current_path}" "$HOME/.bin/tmux-note.sh"

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -121,6 +121,9 @@ bind t run-shell '(tmux switch-client -l || tmux switch-client -n) && tmux kill-
 # Rename current session (. is easy to type, next to , for window)
 bind . command-prompt -p "Rename session:" "rename-session '%%'"
 
+# Worktree manager (create/remove)
+bind W display-popup -E -w 60% -h 50% "$HOME/.bin/tmux-wt.sh"
+
 # Branch notes
 bind n display-popup -E -w 90% -h 90% -d "#{pane_current_path}" "$HOME/.bin/tmux-note.sh"
 bind N display-popup -E -w 50% -h 40% -d "#{pane_current_path}" "$HOME/.bin/tmux-note-add.sh"

--- a/.zshrc
+++ b/.zshrc
@@ -1,5 +1,5 @@
 # Basic Path Setup
-export PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+export PATH="$HOME/.bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 
 # Homebrew Setup
 if [ -f "/opt/homebrew/bin/brew" ]; then

--- a/.zshrc
+++ b/.zshrc
@@ -75,6 +75,13 @@ wt() {
     fi
 }
 
+# Branch note quick-add
+t() { "$HOME/.bin/branch-note.sh" add todo "$*" }
+unalias r 2>/dev/null  # override zsh's default r=fc (repeat last command)
+r() { "$HOME/.bin/branch-note.sh" add research "$*" }
+c() { "$HOME/.bin/branch-note.sh" add collab "$*" }
+a() { "$HOME/.bin/branch-note.sh" add ask "$*" }
+
 # Kanata
 alias kanata-restart="sudo launchctl unload /Library/LaunchDaemons/com.custom.kanata.plist && sudo launchctl load /Library/LaunchDaemons/com.custom.kanata.plist"
 alias kanata-log="cat /tmp/kanata.out /tmp/kanata.err"


### PR DESCRIPTION
## Summary

- Add a per-branch note system integrated with tmux, git worktrees, and Claude Code
- Notes stored in `personal-notes/branch-notes/` (Obsidian-compatible) with structured sections: Goal, Todos, Blockers, Decisions, To Research, Collaboration, To Ask
- Two tmux popup modes: full editor (`prefix+n`) and quick-add with fzf (`prefix+N`)
- Shell shortcuts `t`/`r`/`c`/`a` for instant capture from terminal
- Tmux status bar shows open todo count per branch in red
- Window section sync via tmux hooks (after-new-window, window-renamed)
- Claude Code `/get-context` skill + CLAUDE.md instructions for AI-assisted workflows

## New scripts
| Script | Purpose |
|--------|---------|
| `.bin/branch-note.sh` | Core resolver: create/cat/edit/add/list/summary |
| `.bin/branch-note-status.sh` | Tmux status bar todo count |
| `.bin/tmux-note.sh` | Popup editor with window sync |
| `.bin/tmux-note-add.sh` | Quick-add popup (fzf section picker) |
| `.bin/tmux-note-sync.sh` | Hook-driven window section sync |

## Modified files
| File | Change |
|------|--------|
| `.bin/tmux-lib.sh` | `resolve_note_context()` helper |
| `.tmux.conf` | Keybindings, status line, window hooks |
| `.zshrc` | `t`/`r`/`c`/`a` quick-add functions |

## Tracking issues
Closes #49, closes #50, closes #51, closes #52, closes #53, closes #54, closes #55, closes #56, closes #57, closes #58

## Test plan
- [ ] `prefix + n` in a git repo creates and opens note with template
- [ ] `prefix + N` shows fzf picker, inserts into correct section
- [ ] `t fix bug` from terminal adds to Todos with checkbox
- [ ] Status bar shows `branch [N]` with todo count
- [ ] Window sync hooks append `### window-name` on new-window/rename
- [ ] Works in both regular clones and worktrees
- [ ] `branch-note list` and `branch-note summary` show cross-repo dashboard
- [ ] `/get-context` in Claude Code loads note + investigation files

🤖 Generated with [Claude Code](https://claude.com/claude-code)