### PR TITLE
Fix tat nullglob, install nvim/fzf from GitHub, add wira360

### DIFF
--- a/.bin/setup/arch.sh
+++ b/.bin/setup/arch.sh
@@ -90,6 +90,8 @@ setup_arch() {
     install_nvm
     install_common_packages_arch
     ensure_tmux_version
+    install_neovim
+    install_fzf
     install_arch_specific_packages
 
     install_lazygit

--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -176,10 +176,13 @@ clone_repos() {
             "git@github.com:eduuh/nvim.git"
             "git@github.com:eduuh-private/personal-notes.git"
             "git@github.com:eduuh/eduuh.git"
-            "git@github.com:eduuh/wira360.git"
         )
 
-        if [ "$is_wsl" = false ]; then
+        if [ "$is_wsl" = true ] && [ "$(hostname)" = "edwin" ]; then
+            REPOSITORIES+=(
+                "git@github.com:eduuh/wira360.git"
+            )
+        elif [ "$is_wsl" = false ]; then
             REPOSITORIES+=(
                 "git@github.com:eduuh/kube-homelab.git"
                 "git@github.com:eduuh/blog-2026.git"

--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -61,11 +61,11 @@ print_failure_summary() {
 # Note: zoxide is NOT in Ubuntu apt repos, so it's installed separately via install_zoxide
 if [ "$CODESPACES" = "true" ]; then
     common_software=(
-        git stow fzf ripgrep tmux zsh unzip neovim tree jq
+        git stow ripgrep tmux zsh unzip tree jq
     )
 else
     common_software=(
-        git stow make cmake fzf ripgrep tmux zsh unzip neovim tree jq
+        git stow make cmake ripgrep tmux zsh unzip tree jq
     )
 fi
 
@@ -176,13 +176,13 @@ clone_repos() {
             "git@github.com:eduuh/nvim.git"
             "git@github.com:eduuh-private/personal-notes.git"
             "git@github.com:eduuh/eduuh.git"
+            "git@github.com:eduuh/wira360.git"
         )
 
         if [ "$is_wsl" = false ]; then
             REPOSITORIES+=(
                 "git@github.com:eduuh/kube-homelab.git"
                 "git@github.com:eduuh/blog-2026.git"
-                "git@github.com:eduuh/tracker.git"
                 "git@github.com:eduuh/growatt_exporter.git"
                 "git@github.com:eduuh-private/byte_s.git"
                 "git@github.com:eduuh-private/bash.git"
@@ -289,6 +289,54 @@ install_tmux_plugins() {
     else
         track_failure "tmux" "Failed to clone TPM repository"
     fi
+}
+
+install_neovim() {
+    echo "Installing Neovim from GitHub releases..."
+    local install_dir="$HOME/.local/bin"
+    mkdir -p "$install_dir"
+
+    local arch=$(uname -m)
+    local tarball="nvim-linux-${arch}.tar.gz"
+    local url="https://github.com/neovim/neovim/releases/latest/download/${tarball}"
+
+    if ! curl -sL "$url" -o "/tmp/${tarball}"; then
+        track_failure "neovim" "Failed to download Neovim"
+        return 1
+    fi
+
+    tar -xzf "/tmp/${tarball}" -C /tmp
+    cp "/tmp/nvim-linux-${arch}/bin/nvim" "$install_dir/nvim"
+    chmod +x "$install_dir/nvim"
+    rm -rf "/tmp/${tarball}" "/tmp/nvim-linux-${arch}"
+
+    echo "Neovim $("$install_dir/nvim" --version | head -1) installed to $install_dir"
+}
+
+install_fzf() {
+    echo "Installing fzf from GitHub releases..."
+    local install_dir="$HOME/.local/bin"
+    mkdir -p "$install_dir"
+
+    local version
+    version=$(curl -s "https://api.github.com/repos/junegunn/fzf/releases/latest" | grep -Po '"tag_name": *"v\K[^"]*')
+    if [[ -z "$version" ]]; then
+        track_failure "fzf" "Failed to fetch fzf version"
+        return 1
+    fi
+
+    local url="https://github.com/junegunn/fzf/releases/download/v${version}/fzf-${version}-linux_amd64.tar.gz"
+
+    if ! curl -sL "$url" -o /tmp/fzf.tar.gz; then
+        track_failure "fzf" "Failed to download fzf"
+        return 1
+    fi
+
+    tar -xzf /tmp/fzf.tar.gz -C "$install_dir" fzf
+    chmod +x "$install_dir/fzf"
+    rm -f /tmp/fzf.tar.gz
+
+    echo "fzf $("$install_dir/fzf" --version) installed to $install_dir"
 }
 
 install_lazygit() {

--- a/.bin/setup/ubuntu.sh
+++ b/.bin/setup/ubuntu.sh
@@ -75,6 +75,8 @@ setup_ubuntu() {
     update_system
     install_common_packages
     ensure_tmux_version
+    install_neovim
+    install_fzf
     install_ubuntu_specific_packages
 
     if [[ $CODESPACES != "true" ]]; then
@@ -90,6 +92,8 @@ setup_codespace() {
     update_system
     install_common_packages
     ensure_tmux_version
+    install_neovim
+    install_fzf
     install_claude_code
     setup_python
     setup_symlinks

--- a/.bin/tat
+++ b/.bin/tat
@@ -29,7 +29,7 @@ get_projects() {
     fi
 
     # Regular clones: ~/projects/*/ excluding bare/, worktree/, hidden dirs
-    for dir in "$PROJECT_ROOT"/*/; do
+    for dir in "$PROJECT_ROOT"/*/(N); do
         [[ -d "$dir" ]] || continue
         local name=$(basename "$dir")
         [[ "$name" == .* ]] && continue

--- a/.bin/tat
+++ b/.bin/tat
@@ -17,10 +17,10 @@ get_projects() {
 
     # Worktree entries: ~/projects/worktree/repo/branch → "repo/branch"
     if [[ -d "$WORKTREE_DIR" ]]; then
-        for repo_dir in "$WORKTREE_DIR"/*/; do
+        for repo_dir in "$WORKTREE_DIR"/*/(N); do
             [[ -d "$repo_dir" ]] || continue
             local repo_name=$(basename "$repo_dir")
-            for branch_dir in "$repo_dir"/*/; do
+            for branch_dir in "$repo_dir"/*/(N); do
                 [[ -d "$branch_dir" ]] || continue
                 local branch_name=$(basename "$branch_dir")
                 projects+=("${repo_name}/${branch_name}")


### PR DESCRIPTION
## Summary
- Fix `tat` showing empty project list by adding `(N)` nullglob qualifier to zsh globs (empty `worktree/` dir caused script abort)
- Install nvim and fzf from GitHub releases instead of apt (apt versions are outdated: nvim 0.9.5, fzf 0.44.1)
- Add wira360 repo clone restricted to WSL host `edwin`
- Remove old `tracker` repo reference

## Test plan
- [ ] Run `prefix + C-o` with empty worktree dir — should list all projects
- [ ] Run setup script on Ubuntu — nvim and fzf install from GitHub releases
- [ ] Run setup on WSL `edwin` — wira360 is cloned
- [ ] Run setup on other machines — wira360 is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)