### PR TITLE
fix: Termux setup - correct zsh path and no-sudo shell change

### DIFF
--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -602,20 +602,29 @@ change_shell_to_zsh() {
         return 0
     fi
 
-    if [[ "$SHELL" != "/bin/zsh" ]]; then
-        echo "Changing default shell to zsh..."
+    local zsh_path
+    zsh_path=$(command -v zsh)
+
+    if [[ "$SHELL" != "$zsh_path" ]]; then
+        echo "Changing default shell to zsh ($zsh_path)..."
 
         # Handle platform-specific shell change commands
         case "$(detect_distro)" in
             darwin)
                 # macOS doesn't need sudo for chsh
-                if ! chsh -s /bin/zsh; then
+                if ! chsh -s "$zsh_path"; then
+                    track_failure "shell" "Failed to change shell to zsh"
+                fi
+                ;;
+            termux)
+                # Termux has no sudo; chsh works directly
+                if ! chsh -s "$zsh_path"; then
                     track_failure "shell" "Failed to change shell to zsh"
                 fi
                 ;;
             *)
                 # Linux distributions typically need sudo
-                if ! sudo chsh -s /bin/zsh $USER; then
+                if ! sudo chsh -s "$zsh_path" "$USER"; then
                     track_failure "shell" "Failed to change shell to zsh"
                 fi
                 ;;


### PR DESCRIPTION
## Summary

- Use `command -v zsh` instead of hardcoded `/bin/zsh` so the shell path resolves correctly on Termux (`$PREFIX/bin/zsh`) and all other platforms
- Add explicit `termux` case in `change_shell_to_zsh` to call `chsh` without `sudo` (Termux has no sudo)

## Verification

All confirmed available via `pkg install` from official [termux-packages](https://github.com/termux/termux-packages):
- `git`, `stow`, `ripgrep`, `tmux`, `zsh`, `unzip`, `tree`, `jq`, `make`, `cmake`
- `fzf`, `zoxide`, `starship`, `neovim`, `lazygit`

## Test plan
- [ ] Run `setup.sh` on a fresh Termux install and verify packages install correctly
- [ ] Verify zsh becomes the default shell after setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)