### PR TITLE
feat: bn blog/learn commands, bare repo layout, Termux fix

### DIFF
--- a/.bin/bn
+++ b/.bin/bn
@@ -1877,34 +1877,32 @@ cmd_blog() {
 
     case "$subcmd" in
         list|l)
+            local filter="${1:-all}"
             local drafts_dir="$BLOG_DRAFTS/posts"
             printf "%-50s %s\n" "SLUG" "STATUS"
             printf "%-50s %s\n" "----" "------"
             if [[ -d "$drafts_dir" ]]; then
-                # Local: read frontmatter
                 for f in "$drafts_dir"/*.mdx(N); do
                     local slug="${f:t:r}"
                     local post_status="draft"
                     grep -q '^published: true' "$f" && post_status="published"
-                    printf "%-50s %s\n" "$slug" "$post_status"
+                    case "$filter" in
+                        published) [[ "$post_status" == "published" ]] && printf "%-50s %s\n" "$slug" "$post_status" ;;
+                        drafts)    [[ "$post_status" == "draft" ]]     && printf "%-50s %s\n" "$slug" "$post_status" ;;
+                        *)         printf "%-50s %s\n" "$slug" "$post_status" ;;
+                    esac
                 done
             else
-                # Fallback: parse live sitemap
+                # Fallback: parse live sitemap (published only)
                 echo "(local worktree unavailable — fetching from eduuh.com)" >&2
                 curl -s https://eduuh.com/sitemap.xml \
                     | grep -o 'eduuh\.com/blog/[^<]*' \
                     | sed 's|eduuh\.com/blog/||' \
                     | while read -r slug; do
+                        [[ "$filter" == "drafts" ]] && continue
                         printf "%-50s %s\n" "$slug" "published (live)"
                     done
             fi
-            ;;
-        drafts|d)
-            local drafts_dir="$BLOG_DRAFTS/posts"
-            [[ ! -d "$drafts_dir" ]] && { echo "Drafts worktree not found: $drafts_dir" >&2; return 1; }
-            for f in "$drafts_dir"/*.mdx(N); do
-                grep -q '^published: true' "$f" || echo "${f:t:r}"
-            done
             ;;
         new|n)
             local slug="$1"
@@ -2046,7 +2044,8 @@ Filtering:
 
 Blog (bits-and-atoms):
   blog list               List all posts with published/draft status
-  blog drafts             List only unpublished posts
+  blog list published     List only published posts (falls back to eduuh.com)
+  blog list drafts        List only unpublished posts
   blog new <slug>         Create new draft post and open in $EDITOR
   blog publish <slug>     Mark published, commit, push drafts, open draft PR to main
   blog open <slug>        Open a post in $EDITOR

--- a/.bin/bn
+++ b/.bin/bn
@@ -1868,6 +1868,115 @@ cmd_diff() {
     echo -e "${GREEN}${commits} commit(s) ahead of main${NC}"
 }
 
+cmd_blog() {
+    local BLOG_BARE="$HOME/projects/bare/bits-and-atoms.git"
+    local BLOG_DRAFTS="$HOME/projects/worktree/bits-and-atoms/drafts"
+    local BLOG_MAIN="$HOME/projects/worktree/bits-and-atoms/main"
+    local subcmd="${1:-list}"
+    shift 2>/dev/null || true
+
+    case "$subcmd" in
+        list|l)
+            local drafts_dir="$BLOG_DRAFTS/posts"
+            [[ ! -d "$drafts_dir" ]] && { echo "Drafts worktree not found: $drafts_dir" >&2; return 1; }
+            printf "%-50s %s\n" "SLUG" "STATUS"
+            printf "%-50s %s\n" "----" "------"
+            for f in "$drafts_dir"/*.mdx(N); do
+                local slug="${f:t:r}"
+                local post_status="draft"
+                grep -q '^published: true' "$f" && post_status="published"
+                printf "%-50s %s\n" "$slug" "$post_status"
+            done
+            ;;
+        drafts|d)
+            local drafts_dir="$BLOG_DRAFTS/posts"
+            [[ ! -d "$drafts_dir" ]] && { echo "Drafts worktree not found: $drafts_dir" >&2; return 1; }
+            for f in "$drafts_dir"/*.mdx(N); do
+                grep -q '^published: true' "$f" || echo "${f:t:r}"
+            done
+            ;;
+        new|n)
+            local slug="$1"
+            [[ -z "$slug" ]] && { echo "Usage: bn blog new <slug>" >&2; return 1; }
+            local post_file="$BLOG_DRAFTS/posts/${slug}.mdx"
+            [[ -f "$post_file" ]] && { echo "Post already exists: $post_file" >&2; return 1; }
+            local date=$(date +%Y-%m-%d)
+            # Capitalise each word of slug for title
+            local title="${(C)${slug//-/ }}"
+            cat > "$post_file" <<POSTEOF
+---
+title: $title
+slug: $slug
+publishedAt: '$date'
+summary:
+tags:
+  -
+published: false
+# series:
+#   title: Series Name
+#   order: 1
+---
+
+POSTEOF
+            echo "Created: $post_file"
+            ${EDITOR:-nvim} "$post_file"
+            ;;
+        publish|p)
+            local slug="$1"
+            [[ -z "$slug" ]] && { echo "Usage: bn blog publish <slug>" >&2; return 1; }
+            local post_file="$BLOG_DRAFTS/posts/${slug}.mdx"
+            [[ ! -f "$post_file" ]] && { echo "Post not found: $post_file" >&2; return 1; }
+
+            # Read title from frontmatter
+            local title=""
+            while IFS= read -r line; do
+                [[ "$line" == title:* ]] && { title="${line#title: }"; break; }
+            done < "$post_file"
+            [[ -z "$title" ]] && title="$slug"
+
+            # Mark published
+            sed -i '' 's/^published: false/published: true/' "$post_file"
+            echo "Marked as published: $slug"
+
+            # Commit
+            (
+                cd "$BLOG_DRAFTS"
+                git add "posts/${slug}.mdx"
+                git commit -m "post: $title"
+                git push origin drafts
+            )
+
+            # Create draft PR (skip if one already exists for this branch)
+            local existing_pr
+            existing_pr=$(GIT_DIR="$BLOG_BARE" gh pr list --repo eduuh/bits-and-atoms \
+                --head drafts --base main --json number --jq '.[0].number' 2>/dev/null)
+            if [[ -n "$existing_pr" ]]; then
+                echo "Draft PR already open: https://github.com/eduuh/bits-and-atoms/pull/$existing_pr"
+            else
+                gh pr create \
+                    --repo eduuh/bits-and-atoms \
+                    --draft \
+                    --base main \
+                    --head drafts \
+                    --title "post: $title" \
+                    --body "Publishes: \`posts/${slug}.mdx\`"
+            fi
+            ;;
+        open|o)
+            local slug="$1"
+            [[ -z "$slug" ]] && { echo "Usage: bn blog open <slug>" >&2; return 1; }
+            local post_file="$BLOG_DRAFTS/posts/${slug}.mdx"
+            [[ ! -f "$post_file" ]] && post_file="$BLOG_MAIN/posts/${slug}.mdx"
+            [[ ! -f "$post_file" ]] && { echo "Post not found: $slug" >&2; return 1; }
+            ${EDITOR:-nvim} "$post_file"
+            ;;
+        *)
+            echo "Usage: bn blog <list|drafts|new|publish|open>" >&2
+            return 1
+            ;;
+    esac
+}
+
 cmd_help() {
     cat << 'HELPEOF'
 Usage: bn [command]
@@ -1924,6 +2033,13 @@ Filtering:
   Notes without a machine field are always shown.
   Use --all-machines with list to see notes from all hosts.
 
+Blog (bits-and-atoms):
+  blog list               List all posts with published/draft status
+  blog drafts             List only unpublished posts
+  blog new <slug>         Create new draft post and open in $EDITOR
+  blog publish <slug>     Mark published, commit, push drafts, open draft PR to main
+  blog open <slug>        Open a post in $EDITOR
+
 Sections: todo, blocker, decision, research, collab, ask
 HELPEOF
 }
@@ -1959,6 +2075,7 @@ case "${1:-}" in
     diff|d)             cmd_diff ;;
     achieve|ac)         shift; cmd_achieve "$@" ;;
     global|g)           shift; cmd_global "$@" ;;
+    blog)               shift; cmd_blog "$@" ;;
     -h|--help|help)     cmd_help ;;
     "")                 cmd_default ;;
     *)                  echo "Unknown command: $1" >&2; exit 1 ;;

--- a/.bin/bn
+++ b/.bin/bn
@@ -1878,15 +1878,26 @@ cmd_blog() {
     case "$subcmd" in
         list|l)
             local drafts_dir="$BLOG_DRAFTS/posts"
-            [[ ! -d "$drafts_dir" ]] && { echo "Drafts worktree not found: $drafts_dir" >&2; return 1; }
             printf "%-50s %s\n" "SLUG" "STATUS"
             printf "%-50s %s\n" "----" "------"
-            for f in "$drafts_dir"/*.mdx(N); do
-                local slug="${f:t:r}"
-                local post_status="draft"
-                grep -q '^published: true' "$f" && post_status="published"
-                printf "%-50s %s\n" "$slug" "$post_status"
-            done
+            if [[ -d "$drafts_dir" ]]; then
+                # Local: read frontmatter
+                for f in "$drafts_dir"/*.mdx(N); do
+                    local slug="${f:t:r}"
+                    local post_status="draft"
+                    grep -q '^published: true' "$f" && post_status="published"
+                    printf "%-50s %s\n" "$slug" "$post_status"
+                done
+            else
+                # Fallback: parse live sitemap
+                echo "(local worktree unavailable — fetching from eduuh.com)" >&2
+                curl -s https://eduuh.com/sitemap.xml \
+                    | grep -o 'eduuh\.com/blog/[^<]*' \
+                    | sed 's|eduuh\.com/blog/||' \
+                    | while read -r slug; do
+                        printf "%-50s %s\n" "$slug" "published (live)"
+                    done
+            fi
             ;;
         drafts|d)
             local drafts_dir="$BLOG_DRAFTS/posts"

--- a/.bin/bn
+++ b/.bin/bn
@@ -35,7 +35,7 @@ source "$HOME/.bin/tmux/tmux-lib.sh"
 
 # --- Config ---
 
-NOTES_DIR="$HOME/projects/personal-notes/branch-notes"
+NOTES_DIR="$HOME/projects/worktree/personal-notes/branch-notes/branch-notes"
 _HOSTNAME=$(hostname)
 
 # --- Helpers: Git Context ---
@@ -1986,6 +1986,78 @@ POSTEOF
     esac
 }
 
+cmd_learn() {
+    local LEARN_DIR="$HOME/projects/worktree/personal-notes/learning"
+    local subcmd="${1:-list}"
+    shift 2>/dev/null || true
+
+    case "$subcmd" in
+        new|n)
+            local topic="$1"
+            [[ -z "$topic" ]] && { echo "Usage: bn learn new <topic-name>" >&2; return 1; }
+            local note_file="$LEARN_DIR/${topic}.md"
+            [[ -f "$note_file" ]] && { echo "Topic already exists: $note_file" >&2; return 1; }
+            local date=$(date +%Y-%m-%d)
+            local title="${(C)${topic//-/ }}"
+            cat > "$note_file" <<LEARNEOF
+# $title
+
+> Created: $date
+
+## Topic
+
+What you're learning and why.
+
+## Resources
+
+-
+
+## Key Concepts
+
+-
+
+## Questions
+
+-
+
+## Practice
+
+-
+
+## Links
+
+-
+LEARNEOF
+            echo "Created: $note_file"
+            ${EDITOR:-nvim} "$note_file"
+            ;;
+        list|l)
+            if [[ ! -d "$LEARN_DIR" ]]; then
+                echo "Learning directory not found: $LEARN_DIR" >&2
+                return 1
+            fi
+            local found=0
+            for f in "$LEARN_DIR"/*.md(N); do
+                [[ "${f:t}" == "README.md" ]] && continue
+                printf "%s\n" "${f:t:r}"
+                found=1
+            done
+            (( found )) || echo "(no learning notes yet)"
+            ;;
+        open|o)
+            local topic="$1"
+            [[ -z "$topic" ]] && { echo "Usage: bn learn open <topic>" >&2; return 1; }
+            local note_file="$LEARN_DIR/${topic}.md"
+            [[ ! -f "$note_file" ]] && { echo "Topic not found: $topic" >&2; return 1; }
+            ${EDITOR:-nvim} "$note_file"
+            ;;
+        *)
+            echo "Usage: bn learn <list|new|open>" >&2
+            return 1
+            ;;
+    esac
+}
+
 cmd_help() {
     cat << 'HELPEOF'
 Usage: bn [command]
@@ -2050,6 +2122,11 @@ Blog (bits-and-atoms):
   blog publish <slug>     Mark published, commit, push drafts, open draft PR to main
   blog open <slug>        Open a post in $EDITOR
 
+Learning:
+  learn list              List learning notes
+  learn new <topic>       Create new learning note and open in $EDITOR
+  learn open <topic>      Open a learning note in $EDITOR
+
 Sections: todo, blocker, decision, research, collab, ask
 HELPEOF
 }
@@ -2086,6 +2163,7 @@ case "${1:-}" in
     achieve|ac)         shift; cmd_achieve "$@" ;;
     global|g)           shift; cmd_global "$@" ;;
     blog)               shift; cmd_blog "$@" ;;
+    learn)              shift; cmd_learn "$@" ;;
     -h|--help|help)     cmd_help ;;
     "")                 cmd_default ;;
     *)                  echo "Unknown command: $1" >&2; exit 1 ;;

--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -602,20 +602,29 @@ change_shell_to_zsh() {
         return 0
     fi
 
-    if [[ "$SHELL" != "/bin/zsh" ]]; then
-        echo "Changing default shell to zsh..."
+    local zsh_path
+    zsh_path=$(command -v zsh)
+
+    if [[ "$SHELL" != "$zsh_path" ]]; then
+        echo "Changing default shell to zsh ($zsh_path)..."
 
         # Handle platform-specific shell change commands
         case "$(detect_distro)" in
             darwin)
                 # macOS doesn't need sudo for chsh
-                if ! chsh -s /bin/zsh; then
+                if ! chsh -s "$zsh_path"; then
+                    track_failure "shell" "Failed to change shell to zsh"
+                fi
+                ;;
+            termux)
+                # Termux has no sudo; chsh works directly
+                if ! chsh -s "$zsh_path"; then
                     track_failure "shell" "Failed to change shell to zsh"
                 fi
                 ;;
             *)
                 # Linux distributions typically need sudo
-                if ! sudo chsh -s /bin/zsh $USER; then
+                if ! sudo chsh -s "$zsh_path" "$USER"; then
                     track_failure "shell" "Failed to change shell to zsh"
                 fi
                 ;;

--- a/.bin/wt
+++ b/.bin/wt
@@ -12,7 +12,6 @@ source "$HOME/.bin/tmux/tmux-lib.sh"
 REGULAR_CLONE_REPOS=(
     "dotfiles"
     "nvim"
-    "personal-notes"
 )
 
 usage() {


### PR DESCRIPTION
## Summary
- Add `bn blog` subcommand for managing bits-and-atoms blog posts (list/new/publish/open)
- Add `bn learn` subcommand for learning notes in the personal-notes learning worktree
- Update `bn` NOTES_DIR and `wt` REGULAR_CLONE_REPOS for personal-notes bare repo migration
- Fix Termux shell detection in setup script

## Test plan
- [ ] `bn blog list` / `bn blog list published` / `bn blog list drafts`
- [ ] `bn learn list` / `bn learn new test-topic`
- [ ] `bn --cat` and `bn add todo` resolve to correct worktree path
- [ ] `wt clone` no longer treats personal-notes as regular clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)