### PR TITLE
feat(tmux): open worktrees as windows in current session

### DIFF
--- a/.bin/tmux/tmux-wt-window.sh
+++ b/.bin/tmux/tmux-wt-window.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env zsh
+# tmux-wt-window.sh - Open a worktree as a tmux window in the current session
+# Bound to prefix+o in tmux
+
+source "$HOME/.bin/tmux/tmux-lib.sh"
+tmux_init
+require_fzf
+
+# Gather all worktrees (repo/branch)
+worktrees=()
+for repo_dir in "$WORKTREE_DIR"/*(N/); do
+    local repo_name=$(basename "$repo_dir")
+    for branch_dir in "$repo_dir"/*(N/); do
+        [[ -d "$branch_dir" ]] || continue
+        local branch_name=$(basename "$branch_dir")
+        worktrees+=("${repo_name}/${branch_name}")
+    done
+done
+
+[[ ${#worktrees[@]} -eq 0 ]] && { echo "No worktrees found"; exit 0; }
+
+# fzf picker
+selected=$(printf '%s\n' "${worktrees[@]}" | $FZF_CMD --prompt="Open as window: " --reverse)
+[[ -z "$selected" ]] && exit 0
+
+worktree_path="$WORKTREE_DIR/$selected"
+window_name="$selected"
+
+# If a window with this name already exists, switch to it
+if $TMUX_CMD list-windows -F '#{window_name}' | grep -qxF "$window_name"; then
+    $TMUX_CMD select-window -t "$window_name"
+else
+    $TMUX_CMD new-window -n "$window_name" -c "$worktree_path"
+fi

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -124,6 +124,9 @@ bind . command-prompt -p "Rename session:" "rename-session '%%'"
 # Worktree manager (create/remove)
 bind W display-popup -E -w 60% -h 50% "$HOME/.bin/tmux/tmux-wt.sh '#{pane_current_path}'"
 
+# Open worktree as window in current session
+bind o display-popup -E -w 60% -h 50% "$HOME/.bin/tmux/tmux-wt-window.sh"
+
 # Branch notes
 bind n display-popup -E -w 90% -h 90% -d "#{pane_current_path}" "$HOME/.bin/tmux/tmux-note.sh"
 bind N display-popup -E -w 50% -h 40% -d "#{pane_current_path}" "$HOME/.bin/tmux/tmux-note-add.sh"


### PR DESCRIPTION
## Summary
- Add `tmux-wt-window.sh` — fzf picker that opens a worktree as a named tmux window in the current session (reuses existing window if already open)
- Bind to `prefix+o` in tmux config

## Test plan
- [ ] `prefix R` to reload tmux config
- [ ] `prefix o` opens the fzf worktree picker
- [ ] Selecting a worktree creates a new window named `repo/branch` at the worktree path
- [ ] Selecting the same worktree again switches to the existing window

🤖 Generated with [Claude Code](https://claude.com/claude-code)