### PR TITLE
feat(tmux): persistent nvim/note popups with toggle + quick worktree create

### DIFF
--- a/.bin/tmux/tmux-edit.sh
+++ b/.bin/tmux/tmux-edit.sh
@@ -1,15 +1,24 @@
 #!/usr/bin/env zsh
-# tmux-edit.sh - Open nvim with branch note in a vertical split
-# Called via: bind e display-popup -E ... "$HOME/.bin/tmux/tmux-edit.sh"
+# tmux-edit.sh - Persistent nvim popup, one session per outer tmux session.
+# Toggle: C-Space e opens; the binding detaches the inner client to close.
+# C-a e/d from inside also dismisses. :qa kills the session entirely.
 
 source "$HOME/.bin/tmux/tmux-lib.sh"
+tmux_init
 
-# Resolve branch note path (bn --path prints the note dir)
-note_file=$("$HOME/.bin/bn" --path 2>/dev/null)/note.md
+INNER_SOCKET="nvim"
+INNER_CONF="$HOME/.config/nvim/tmux-inner.conf"
 
-if [[ -f "$note_file" ]]; then
-    # Open nvim: project files + branch note in a right vsplit
-    nvim -c "vsplit $note_file | wincmd h" .
-else
-    nvim .
+outer_session=$($TMUX_CMD display-message -p '#S' 2>/dev/null)
+nvim_session="nvim_${outer_session}"
+pane_path=$($TMUX_CMD display-message -p '#{pane_current_path}' 2>/dev/null)
+pane_path="${pane_path:-$(pwd)}"
+
+if ! tmux -L "$INNER_SOCKET" has-session -t "=$nvim_session" 2>/dev/null; then
+    tmux -L "$INNER_SOCKET" -f "$INNER_CONF" new-session -d -s "$nvim_session" -c "$pane_path" \
+        nvim .
+    tmux -L "$INNER_SOCKET" set-option -t "$nvim_session" status off
 fi
+
+# No exec — shell must stay alive so the popup closes when attach-session returns
+tmux -L "$INNER_SOCKET" attach-session -t "$nvim_session"

--- a/.bin/tmux/tmux-note.sh
+++ b/.bin/tmux/tmux-note.sh
@@ -1,28 +1,33 @@
 #!/usr/bin/env zsh
-# tmux-note.sh - Open branch note in tmux popup
-# Called via: bind n display-popup -E ... "$HOME/.bin/tmux/tmux-note.sh '#{pane_current_path}'"
+# tmux-note.sh - Persistent branch note popup, one session per outer tmux session.
+# Toggle: C-Space n opens; the binding detaches the inner client to close.
+# C-a n/d from inside also dismisses. :q kills the session entirely.
 
 source "$HOME/.bin/tmux/tmux-lib.sh"
 tmux_init
 
-NOTES_DIR="$HOME/projects/worktree/personal-notes/branch-notes/branch-notes"
+INNER_SOCKET="nvim"
+INNER_CONF="$HOME/.config/nvim/tmux-inner.conf"
 
-# cd to pane path so branch-note.sh subcommands resolve correctly
-pane_path="${1:-$(pwd)}"
-cd "$pane_path" 2>/dev/null || { echo "Invalid path: $pane_path"; read -sk1; exit 1; }
-resolve_note_context "$pane_path" || { echo "Not in a git repo"; read -sk1; exit 1; }
+outer_session=$($TMUX_CMD display-message -p '#S' 2>/dev/null)
+note_session="note_${outer_session}"
+pane_path=$($TMUX_CMD display-message -p '#{pane_current_path}' 2>/dev/null)
+pane_path="${pane_path:-$(pwd)}"
 
-# Ensure note exists (creates from template if needed)
-note_dir=$("$HOME/.bin/bn")
-note_file="$note_dir/note.md"
+if ! tmux -L "$INNER_SOCKET" has-session -t "=$note_session" 2>/dev/null; then
+    note_dir=$(cd "$pane_path" && "$HOME/.bin/bn" 2>/dev/null)
+    note_file="${note_dir}/note.md"
 
-# Sync window sections
-$TMUX_CMD list-windows -F '#{window_name}' 2>/dev/null | while IFS= read -r win; do
-    if ! grep -Fq "### $win" "$note_file" 2>/dev/null; then
-        echo "" >> "$note_file"
-        echo "### $win" >> "$note_file"
-    fi
-done
+    $TMUX_CMD list-windows -F '#{window_name}' 2>/dev/null | while IFS= read -r win; do
+        if ! grep -Fq "### $win" "$note_file" 2>/dev/null; then
+            printf '\n### %s\n' "$win" >> "$note_file"
+        fi
+    done
 
-# Open in editor
-${EDITOR:-nvim} "$note_file"
+    tmux -L "$INNER_SOCKET" -f "$INNER_CONF" new-session -d -s "$note_session" -c "$pane_path" \
+        nvim "$note_file"
+    tmux -L "$INNER_SOCKET" set-option -t "$note_session" status off
+fi
+
+# No exec — shell must stay alive so the popup closes when attach-session returns
+tmux -L "$INNER_SOCKET" attach-session -t "$note_session"

--- a/.bin/tmux/tmux-wt-new.sh
+++ b/.bin/tmux/tmux-wt-new.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env zsh
+# tmux-wt-new.sh - Streamlined worktree creation from the current session's bare repo
+# Bound to C-Space C-w.
+# Prompts for a branch name, branches off latest main, creates the worktree, runs
+# `bn build`, and opens a new tmux window for it.
+
+source "$HOME/.bin/tmux/tmux-lib.sh"
+tmux_init
+
+session=$($TMUX_CMD display-message -p '#S' 2>/dev/null)
+bare_repo="$BARE_DIR/${session}.git"
+
+if [[ ! -d "$bare_repo" ]]; then
+    echo "Session '$session' is not linked to a bare repo at $bare_repo"
+    read -sk1 "?Press any key..."
+    exit 1
+fi
+
+echo "Repo: $session"
+echo "Fetching origin..."
+git --git-dir="$bare_repo" fetch origin || {
+    echo "Fetch failed"
+    read -sk1 "?Press any key..."
+    exit 1
+}
+
+git --git-dir="$bare_repo" branch -f main origin/main 2>/dev/null
+
+printf "Branch name: "
+read -r branch_name
+[[ -z "$branch_name" ]] && exit 0
+
+sanitized=$(echo "$branch_name" | tr '/' '-')
+worktree_path="$WORKTREE_DIR/${session}/${sanitized}"
+
+if [[ -d "$worktree_path" ]]; then
+    echo "Worktree already exists: $worktree_path"
+    read -sk1 "?Press any key..."
+    exit 0
+fi
+
+echo "Creating worktree: $worktree_path"
+mkdir -p "$WORKTREE_DIR/${session}"
+if ! git --git-dir="$bare_repo" worktree add -b "$branch_name" "$worktree_path" main; then
+    echo "Failed to create worktree"
+    read -sk1 "?Press any key..."
+    exit 1
+fi
+
+(cd "$worktree_path" && "$HOME/.bin/bn" build 2>/dev/null) || true
+
+window_name="$sanitized"
+if $TMUX_CMD list-windows -F '#{window_name}' | grep -qxF "$window_name"; then
+    $TMUX_CMD select-window -t "$window_name"
+else
+    $TMUX_CMD new-window -n "$window_name" -c "$worktree_path"
+fi

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -124,11 +124,16 @@ bind . command-prompt -p "Rename session:" "rename-session '%%'"
 # Worktree manager (create/remove)
 bind W display-popup -E -w 60% -h 50% "$HOME/.bin/tmux/tmux-wt.sh '#{pane_current_path}'"
 
+# Streamlined new worktree from session repo's latest main
+bind C-w display-popup -E -w 60% -h 30% "$HOME/.bin/tmux/tmux-wt-new.sh"
+
 # Open worktree as window in current session
 bind o display-popup -E -w 60% -h 50% "$HOME/.bin/tmux/tmux-wt-window.sh"
 
 # Branch notes
-bind n display-popup -E -w 90% -h 90% -d "#{pane_current_path}" "$HOME/.bin/tmux/tmux-note.sh"
+bind n if-shell 'tmux -L nvim list-clients -t "note_#{session_name}" 2>/dev/null | grep -q .' \
+    'run-shell "tmux -L nvim detach-client -t note_#{session_name} 2>/dev/null"' \
+    'display-popup -E -w 97% -h 97% -d "#{pane_current_path}" "$HOME/.bin/tmux/tmux-note.sh"'
 bind N display-popup -E -w 50% -h 40% -d "#{pane_current_path}" "$HOME/.bin/tmux/tmux-note-add.sh"
 
 # Open matching repos in synchronized panes (prefix S)
@@ -223,10 +228,10 @@ bind -T off k \
 # Popups & Tools
 #----------------------------------------------------------------------------
 
-# Editor popup (nvim + branch note) — toggle: prefix+e shows/hides without killing nvim
-bind e if-shell '[ "$(tmux show -gqv @editor_#S)" = "on" ]' \
-  'detach-client' \
-  'display-popup -E -w 90% -h 90% -d "#{pane_current_path}" "tmux set -g @editor_#S on; tmux new-session -A -s _edit_#S \"$HOME/.bin/tmux/tmux-edit.sh\"; tmux set -g @editor_#S off"'
+# Editor popup (nvim + branch note) — toggle via inner -L nvim socket
+bind e if-shell 'tmux -L nvim list-clients -t "nvim_#{session_name}" 2>/dev/null | grep -q .' \
+    'run-shell "tmux -L nvim detach-client -t nvim_#{session_name} 2>/dev/null"' \
+    'display-popup -E -w 97% -h 97% -d "#{pane_current_path}" "$HOME/.bin/tmux/tmux-edit.sh"'
 
 # Lazygit
 bind g display-popup -E -w 90% -h 90% -d "#{pane_current_path}" "lazygit"


### PR DESCRIPTION
## Summary
- `tmux-edit.sh` / `tmux-note.sh` use an inner tmux session on the `-L nvim` socket (one per outer session) so nvim state survives popup close/reopen.
- `bind e` / `bind n` now toggle: `list-clients` check detaches the inner client when popup is open, otherwise opens fresh. No `exec` so the shell wrapper exits cleanly when `attach-session` returns.
- Popups resized to 97%.
- New `bind C-w` → `tmux-wt-new.sh`: streamlined worktree create from the session's bare repo — fetch origin, branch from latest main, run `bn build`, open as window.

## Test plan
- [ ] `C-Space e` opens persistent nvim popup
- [ ] `C-Space e` again closes popup without killing nvim session
- [ ] `C-Space e` after close reattaches to existing nvim state
- [ ] `C-Space n` toggles note popup the same way
- [ ] `C-Space C-w` in a session matching a bare repo prompts for a branch name and creates/opens the worktree window