### PR TITLE
chore: sync local bn improvements + add notes-on-Windows migration

### DIFF
--- a/.bin/bn
+++ b/.bin/bn
@@ -2794,6 +2794,64 @@ cmd_details() {
     esac
 }
 
+cmd_setup() {
+    require_git_context
+    local main_dir="$NOTES_DIR/$NOTE_REPO/main"
+    local details_file="$main_dir/Details.md"
+    local scripts_dir="$main_dir/scripts"
+    local build_script="$scripts_dir/build"
+
+    echo -e "${BLUE}Setting up bn for: $NOTE_REPO${NC}"
+    echo ""
+
+    # Step 1: Details.md
+    if [[ -f "$details_file" ]]; then
+        echo -e "  ${GREEN}✓${NC} Details.md already exists"
+    else
+        mkdir -p "$main_dir"
+        _render_template details.md "REPO=$NOTE_REPO" > "$details_file"
+        echo -e "  ${GREEN}+${NC} Created Details.md"
+        echo ""
+        echo "  Fill in your project links:"
+        echo -n "  Open Details.md now? [Y/n] "
+        read -r answer
+        if [[ "${answer:-y}" =~ ^[Yy]$ ]]; then
+            ${EDITOR:-nvim} "$details_file"
+        fi
+    fi
+
+    # Step 2: build script
+    ensure_scripts_dir "$NOTE_REPO"
+    if [[ -f "$build_script" ]]; then
+        echo -e "  ${GREEN}✓${NC} build script already exists"
+    else
+        cat > "$build_script" << 'SCRIPTEOF'
+#!/usr/bin/env zsh
+set -e
+
+# build script — runs with cwd set to the repo/worktree directory.
+# Add your setup steps here, e.g.:
+#   npm install
+#   yarn
+#   pip install -r requirements.txt
+
+SCRIPTEOF
+        chmod +x "$build_script"
+        echo -e "  ${GREEN}+${NC} Created scripts/build"
+        echo ""
+        echo "  Add your build/setup steps:"
+        echo -n "  Open build script now? [Y/n] "
+        read -r answer
+        if [[ "${answer:-y}" =~ ^[Yy]$ ]]; then
+            ${EDITOR:-nvim} "$build_script"
+        fi
+    fi
+
+    echo ""
+    echo -e "${GREEN}Done.${NC} New branch notes for $NOTE_REPO will auto-include Details.md."
+    echo "Run 'bn build' in any worktree to run the build script."
+}
+
 cmd_blog() {
     local BLOG_BARE="$HOME/projects/bare/bits-and-atoms.git"
     local BLOG_DRAFTS="$HOME/projects/worktree/bits-and-atoms/drafts"
@@ -3334,6 +3392,7 @@ case "${1:-}" in
     diff|d)             cmd_diff ;;
     achieve|ac)         shift; cmd_achieve "$@" ;;
     global|g)           shift; cmd_global "$@" ;;
+    setup)              cmd_setup ;;
     details)            shift; cmd_details "$@" ;;
     blog)               shift; cmd_blog "$@" ;;
     learn)              shift; cmd_learn "$@" ;;

--- a/.bin/bn
+++ b/.bin/bn
@@ -47,14 +47,61 @@ fi
 
 # --- Config ---
 
-NOTES_DIR="$HOME/projects/branch-notes"
+_NOTES_DIR_PERSONAL="$HOME/projects/branch-notes"
+_NOTES_DIR_WORK="$HOME/projects/branch-notes-work"
+
+# Work-repo allowlist is per-machine (sensitive) — kept out of public dotfiles.
+# Format: one repo name per line, '#' comments allowed.
+_WORK_REPOS_FILE="${BN_WORK_REPOS_FILE:-$HOME/.config/bn/work-repos}"
+typeset -ga _WORK_REPOS=()
+if [[ -r "$_WORK_REPOS_FILE" ]]; then
+    while IFS= read -r line; do
+        line="${line%%#*}"
+        line="${line//[[:space:]]/}"
+        [[ -z "$line" ]] && continue
+        _WORK_REPOS+=("$line")
+    done < "$_WORK_REPOS_FILE"
+fi
+
+# Default NOTES_DIR is the personal repo. resolve_note_context overrides this
+# for the current NOTE_REPO when a context is loaded.
+NOTES_DIR="$_NOTES_DIR_PERSONAL"
 _HOSTNAME=$(hostname)
+
+# Is the given repo classified as a work repo (case-sensitive match against allowlist)?
+_is_work_repo() {
+    local r="$1" w
+    for w in "${_WORK_REPOS[@]}"; do
+        [[ "$r" == "$w" ]] && return 0
+    done
+    return 1
+}
+
+# Resolve the notes dir for a specific repo name.
+notes_dir_for() {
+    if _is_work_repo "$1"; then
+        echo "$_NOTES_DIR_WORK"
+    else
+        echo "$_NOTES_DIR_PERSONAL"
+    fi
+}
+
+# Iterate over every existing notes dir (personal first, then work).
+_for_each_notes_dir() {
+    local d
+    for d in "$_NOTES_DIR_PERSONAL" "$_NOTES_DIR_WORK"; do
+        [[ -d "$d" ]] && echo "$d"
+    done
+}
 
 # --- Helpers: Git Context ---
 
 # Resolve git context and exit on failure. Use instead of bare resolve_note_context.
 require_git_context() {
     resolve_note_context "$(pwd)" || { echo "Not in a git repo" >&2; exit 1; }
+    # Point NOTES_DIR at the right repo for the current NOTE_REPO so the
+    # ubiquitous $NOTES_DIR/$NOTE_REPO/... usages just work.
+    NOTES_DIR=$(notes_dir_for "$NOTE_REPO")
 }
 
 # --- Helpers: Git & Frontmatter ---
@@ -189,7 +236,7 @@ _copy_to_clipboard() {
 # fzf-pick a script for <repo>; sets REPLY to the name. Returns 1 if none/cancelled.
 _fzf_pick_script() {
     local repo="$1"
-    local scripts_dir="$NOTES_DIR/$repo/main/scripts"
+    local scripts_dir="$(notes_dir_for "$repo")/$repo/main/scripts"
     local -a scripts
     for f in "$scripts_dir"/*(Nx); do scripts+=("${f:t}"); done
     (( ${#scripts[@]} == 0 )) && return 1
@@ -521,14 +568,15 @@ ensure_global_note() {
 
 # Resolve path to a named script (always in main's note dir)
 resolve_script() {
-    REPLY="$NOTES_DIR/$1/main/scripts/$2"
+    REPLY="$(notes_dir_for "$1")/$1/main/scripts/$2"
 }
 
 # Ensure scripts/ dir exists; auto-migrate old build.sh on first access
 ensure_scripts_dir() {
     local repo="$1"
-    local scripts_dir="$NOTES_DIR/$repo/main/scripts"
-    local old_build_sh="$NOTES_DIR/$repo/main/build.sh"
+    local d="$(notes_dir_for "$repo")"
+    local scripts_dir="$d/$repo/main/scripts"
+    local old_build_sh="$d/$repo/main/build.sh"
 
     mkdir -p "$scripts_dir"
 
@@ -965,8 +1013,11 @@ _pn_for_file() {
 #   _BN_PARSED — raw batch parse output
 # Returns 1 (and prints message) if no notes found.
 _load_all_notes() {
-    [[ ! -d "$NOTES_DIR" ]] && { echo "No branch notes found"; return 1; }
-    _BN_FILES=("$NOTES_DIR"/*/*/note.md(N))
+    _BN_FILES=()
+    local d
+    for d in $(_for_each_notes_dir); do
+        _BN_FILES+=("$d"/*/*/note.md(N))
+    done
     (( ${#_BN_FILES[@]} == 0 )) && { echo "No branch notes found"; return 1; }
     _BN_PARSED=$(_parse_all_notes "${_BN_FILES[@]}")
 }
@@ -1788,7 +1839,7 @@ cmd_reset() {
         git --git-dir="$bare" worktree remove --force "$wt" 2>/dev/null || rm -rf "$wt"
 
         # Close the branch note if it exists
-        local note_file="$NOTES_DIR/${repo_name}/${branch_name}/note.md"
+        local note_file="$(notes_dir_for "$repo_name")/${repo_name}/${branch_name}/note.md"
         if [[ -f "$note_file" ]]; then
             set_note_status "$note_file" "closed"
             echo "  Closed note: ${repo_name}/${branch_name}"
@@ -2347,7 +2398,8 @@ cmd_archive() {
     fi
 
     local archived=0
-    local -a affected_paths=()
+    # Map of notes-dir → space-separated archived "$repo/$branch" entries
+    typeset -A affected_by_dir
 
     if $dry_run; then
         echo -e "${YELLOW}[DRY RUN — no changes will be made]${NC}"
@@ -2366,7 +2418,8 @@ cmd_archive() {
 
         _note_context "$note_file"
         local note_dir=${note_file:h}
-        local dest="$NOTES_DIR/archive/$_repo/$_branch"
+        local notes_root="$(notes_dir_for "$_repo")"
+        local dest="$notes_root/archive/$_repo/$_branch"
 
         if [[ -d "$dest" ]]; then
             echo -e "${RED}Already exists, skipping: archive/$_repo/$_branch${NC}" >&2
@@ -2379,10 +2432,10 @@ cmd_archive() {
             mkdir -p "${dest:h}"
             mv "$note_dir" "$dest"
             archived=$((archived + 1))
-            affected_paths+=("$_repo/$_branch")
+            affected_by_dir[$notes_root]+="$_repo/$_branch "
 
             # Clean up empty repo dir
-            local repo_dir="$NOTES_DIR/$_repo"
+            local repo_dir="$notes_root/$_repo"
             if [[ -d "$repo_dir" ]] && [[ -z "$(ls -A "$repo_dir")" ]]; then
                 rmdir "$repo_dir"
             fi
@@ -2397,16 +2450,21 @@ cmd_archive() {
     else
         echo -e "${GREEN}Archived: $archived note(s)${NC}"
 
-        # Auto-commit only the moved note directories
+        # Commit per notes dir (each is a separate git repo)
         if (( archived > 0 )); then
-            for p in "${affected_paths[@]}"; do
-                git -C "$NOTES_DIR" add -- "archive/$p"
-                git -C "$NOTES_DIR" rm -r --cached --ignore-unmatch --quiet -- "$p"
+            local notes_root
+            for notes_root in ${(k)affected_by_dir}; do
+                local paths=(${=affected_by_dir[$notes_root]})
+                local p
+                for p in $paths; do
+                    git -C "$notes_root" add -- "archive/$p"
+                    git -C "$notes_root" rm -r --cached --ignore-unmatch --quiet -- "$p"
+                done
+                git -C "$notes_root" diff --cached --quiet || {
+                    git -C "$notes_root" commit -m "archive ${#paths} note(s)" >/dev/null
+                    echo -e "${GREEN}Committed to $notes_root${NC}"
+                }
             done
-            git -C "$NOTES_DIR" diff --cached --quiet || {
-                git -C "$NOTES_DIR" commit -m "archive ${archived} note(s)" >/dev/null
-                echo -e "${GREEN}Committed to personal-notes${NC}"
-            }
         fi
     fi
 }
@@ -3115,7 +3173,7 @@ LEARNEOF
 
 # --- Cron Jobs ---
 
-_crons_dir() { echo "$NOTES_DIR/$1/main/crons"; }
+_crons_dir() { echo "$(notes_dir_for "$1")/$1/main/crons"; }
 
 cmd_cron() {
     local subcmd="${1:-list}"
@@ -3563,10 +3621,12 @@ cmd_migrate() {
         esac
     done
 
-    [[ ! -d "$NOTES_DIR" ]] && { echo "No notes directory"; exit 0; }
-
     local -a md_files
-    md_files=("$NOTES_DIR"/**/note.md(N))
+    local d
+    for d in $(_for_each_notes_dir); do
+        md_files+=("$d"/**/note.md(N))
+    done
+    [[ ${#md_files[@]} -eq 0 ]] && { echo "No notes found"; exit 0; }
 
     local total=${#md_files[@]}
     local migrated=0 skipped=0
@@ -3579,14 +3639,20 @@ cmd_migrate() {
             continue
         fi
 
+        # Display path relative to its notes root
+        local rel="$md"
+        for d in $(_for_each_notes_dir); do
+            [[ "$md" == "$d"/* ]] && { rel="${md#$d/}"; break; }
+        done
+
         if $dry_run; then
             count=$(_parse_all_notes_md "$md" | grep -cE "\|(OPEN_TODO|TODO|BLOCKER|DECISION|RESEARCH|COLLAB|ASK):")
-            printf "Would migrate: %-60s (%d items)\n" "${md#$NOTES_DIR/}" "$count"
+            printf "Would migrate: %-60s (%d items)\n" "$rel" "$count"
             (( migrated++ ))
             continue
         fi
 
-        echo "Migrating: ${md#$NOTES_DIR/}"
+        echo "Migrating: $rel"
         _migrate_one "$md"
         (( migrated++ ))
     done

--- a/.bin/bn
+++ b/.bin/bn
@@ -2800,6 +2800,7 @@ cmd_setup() {
     local details_file="$main_dir/Details.md"
     local scripts_dir="$main_dir/scripts"
     local build_script="$scripts_dir/build"
+    local test_script="$scripts_dir/test"
 
     echo -e "${BLUE}Setting up bn for: $NOTE_REPO${NC}"
     echo ""
@@ -2847,9 +2848,35 @@ SCRIPTEOF
         fi
     fi
 
+    # Step 3: test script
+    if [[ -f "$test_script" ]]; then
+        echo -e "  ${GREEN}✓${NC} test script already exists"
+    else
+        cat > "$test_script" << 'SCRIPTEOF'
+#!/usr/bin/env zsh
+set -e
+
+# test script — runs with cwd set to the repo/worktree directory.
+# Add your test steps here, e.g.:
+#   npm test
+#   yarn test
+#   pytest
+
+SCRIPTEOF
+        chmod +x "$test_script"
+        echo -e "  ${GREEN}+${NC} Created scripts/test"
+        echo ""
+        echo "  Add your test steps:"
+        echo -n "  Open test script now? [Y/n] "
+        read -r answer
+        if [[ "${answer:-y}" =~ ^[Yy]$ ]]; then
+            ${EDITOR:-nvim} "$test_script"
+        fi
+    fi
+
     echo ""
     echo -e "${GREEN}Done.${NC} New branch notes for $NOTE_REPO will auto-include Details.md."
-    echo "Run 'bn build' in any worktree to run the build script."
+    echo "Run 'bn build' or 'bn build test' in any worktree to run scripts."
 }
 
 cmd_blog() {

--- a/.bin/bn
+++ b/.bin/bn
@@ -182,6 +182,35 @@ _copy_to_clipboard() {
     fi
 }
 
+# --- Helpers: fzf Pickers ---
+
+# fzf-pick a script for <repo>; sets REPLY to the name. Returns 1 if none/cancelled.
+_fzf_pick_script() {
+    local repo="$1"
+    local scripts_dir="$NOTES_DIR/$repo/main/scripts"
+    local -a scripts
+    for f in "$scripts_dir"/*(Nx); do scripts+=("${f:t}"); done
+    (( ${#scripts[@]} == 0 )) && return 1
+    REPLY=$(printf '%s\n' "${scripts[@]}" \
+        | fzf --prompt="script> " --height=10 --no-info 2>/dev/null)
+    [[ -n "$REPLY" ]]
+}
+
+# fzf-pick an investigation file in <note_dir>; sets REPLY to full path. Returns 1 if none/cancelled.
+_fzf_pick_file() {
+    local note_dir="$1"
+    local -a files
+    for f in "$note_dir"/*.md(N); do
+        [[ "${f:t}" == "note.md" ]] && continue
+        files+=("$f")
+    done
+    (( ${#files[@]} == 0 )) && return 1
+    REPLY=$(printf '%s\n' "${files[@]}" \
+        | fzf --prompt="file> " --height=10 --no-info \
+              --preview="cat {}" 2>/dev/null)
+    [[ -n "$REPLY" ]]
+}
+
 # --- Helpers: Note Templates ---
 
 TEMPLATE_DIR="$HOME/.config/bn/templates"
@@ -213,6 +242,7 @@ _render_template() {
             pr-review.md) _pr_review_template_inline "${(@)@}" ;;
             achievement.md) _achievement_template_inline "${(@)@}" ;;
             achievements-header.md) _achievements_header_template_inline "${(@)@}" ;;
+            details.md) _details_template_inline "${(@)@}" ;;
             *) echo "Unknown template: $tmpl_name" >&2; return 1 ;;
         esac
     fi
@@ -402,6 +432,21 @@ _achievement_template_inline() {
 EOF
 }
 
+_details_template_inline() {
+    local repo=""
+    for pair in "$@"; do case "${pair%%=*}" in REPO) repo="${pair#*=}" ;; esac; done
+    cat << EOF
+# $repo — Details
+
+## Links
+
+-
+
+## Context
+
+EOF
+}
+
 _achievements_header_template_inline() {
     local repo="" date=""
     for pair in "$@"; do
@@ -434,6 +479,11 @@ ensure_note() {
             "REPO=$NOTE_REPO" "BRANCH=$NOTE_BRANCH" \
             "DATE=$(date +%Y-%m-%d)" "MACHINE=$_HOSTNAME" \
             "GOAL=$goal" > "$note_file"
+        local details_file="$NOTES_DIR/$NOTE_REPO/main/Details.md"
+        if [[ -f "$details_file" ]]; then
+            printf '\n---\n' >> "$note_file"
+            cat "$details_file" >> "$note_file"
+        fi
     fi
     if [[ ! -f "$yaml_file" && -f "$note_file" ]]; then
         # Only create yaml for genuinely new notes (prose-only md). Existing md-backed
@@ -1057,7 +1107,6 @@ cmd_files() {
             ${EDITOR:-nvim} "$filepath"
             ;;
         "")
-            # List investigation files
             local -a inv_files
             for f in "$note_dir"/*.md(N); do
                 [[ "${f:t}" == "note.md" ]] && continue
@@ -1068,12 +1117,15 @@ cmd_files() {
                 echo "Create one with: bn files new <name>"
                 return
             fi
-            echo "Investigation files ($NOTE_REPO/$NOTE_BRANCH):"
-            for f in "${inv_files[@]}"; do
-                local lines
-                lines=$(wc -l < "$f" | tr -d ' ')
-                echo "  ${f:t} ($lines lines)"
-            done
+            if command -v fzf &>/dev/null; then
+                _fzf_pick_file "$note_dir" && ${EDITOR:-nvim} "$REPLY"
+            else
+                echo "Investigation files ($NOTE_REPO/$NOTE_BRANCH):"
+                for f in "${inv_files[@]}"; do
+                    local lines; lines=$(wc -l < "$f" | tr -d ' ')
+                    echo "  ${f:t} ($lines lines)"
+                done
+            fi
             ;;
         *)
             # View a specific file
@@ -1917,11 +1969,23 @@ cmd_main() {
     fi
 }
 
-# Run a named script (default: build)
+# Run a named script (default: build). No name → tries "build", then fzf.
 cmd_build() {
-    local name="${1:-build}"
+    local name="${1:-}"
     require_git_context
     ensure_scripts_dir "$NOTE_REPO"
+
+    if [[ -z "$name" ]]; then
+        local default_script; resolve_script "$NOTE_REPO" "build"; default_script=$REPLY
+        if [[ -f "$default_script" ]]; then
+            name="build"
+        elif command -v fzf &>/dev/null && _fzf_pick_script "$NOTE_REPO"; then
+            name="$REPLY"
+        else
+            echo "No scripts for $NOTE_REPO. Create one with: bn script new <name>" >&2
+            exit 1
+        fi
+    fi
 
     local script
     resolve_script "$NOTE_REPO" "$name"; script=$REPLY
@@ -1974,9 +2038,15 @@ SCRIPTEOF
             ;;
         edit)
             local name="$1"
-            [[ -z "$name" ]] && { echo "Usage: bn script edit <name>" >&2; exit 1; }
             require_git_context
             ensure_scripts_dir "$NOTE_REPO"
+            if [[ -z "$name" ]]; then
+                if command -v fzf &>/dev/null && _fzf_pick_script "$NOTE_REPO"; then
+                    name="$REPLY"
+                else
+                    echo "Usage: bn script edit <name>" >&2; exit 1
+                fi
+            fi
 
             local script
             resolve_script "$NOTE_REPO" "$name"; script=$REPLY
@@ -1986,7 +2056,7 @@ SCRIPTEOF
             fi
             ${EDITOR:-nvim} "$script"
             ;;
-        list|l|"")
+        list|l)
             require_git_context
             ensure_scripts_dir "$NOTE_REPO"
 
@@ -2003,6 +2073,27 @@ SCRIPTEOF
             else
                 echo "No scripts for $NOTE_REPO"
                 echo "Create one with: bn script new <name>"
+            fi
+            ;;
+        "")
+            require_git_context
+            ensure_scripts_dir "$NOTE_REPO"
+            if command -v fzf &>/dev/null && _fzf_pick_script "$NOTE_REPO"; then
+                local script; resolve_script "$NOTE_REPO" "$REPLY"; script=$REPLY
+                [[ -x "$script" ]] || chmod +x "$script"
+                ${EDITOR:-nvim} "$script"
+            else
+                # Fall back to list
+                local scripts_dir="$NOTES_DIR/$NOTE_REPO/main/scripts"
+                local -a scripts
+                for f in "$scripts_dir"/*(Nx); do scripts+=("${f:t}"); done
+                if (( ${#scripts[@]} > 0 )); then
+                    echo "Scripts for $NOTE_REPO:"
+                    for s in "${scripts[@]}"; do echo "  $s"; done
+                else
+                    echo "No scripts for $NOTE_REPO"
+                    echo "Create one with: bn script new <name>"
+                fi
             fi
             ;;
         *)
@@ -2445,6 +2536,12 @@ cmd_pr() {
         # Setting a PR link
         ensure_note
         _set_frontmatter "$note_file" "pr" "$url"
+        local yaml_file="${note_file%.md}.yaml"
+        if [[ -f "$yaml_file" ]]; then
+            _yaml_add "$yaml_file" "collab" "PR: $url" >/dev/null
+        else
+            insert_into_section "$note_file" "## Collaboration" "- PR: $url" 2>/dev/null || true
+        fi
         echo "PR linked: $url"
         return
     fi
@@ -2505,6 +2602,13 @@ cmd_link() {
     if [[ -n "$id" ]]; then
         ensure_note
         _set_frontmatter "$note_file" "work_item" "$id"
+        local wi_url_entry="https://dev.azure.com/office/Office/_workitems/edit/${id}"
+        local yaml_file="${note_file%.md}.yaml"
+        if [[ -f "$yaml_file" ]]; then
+            _yaml_add "$yaml_file" "collab" "WI $id: $wi_url_entry" >/dev/null
+        else
+            insert_into_section "$note_file" "## Collaboration" "- WI $id: $wi_url_entry" 2>/dev/null || true
+        fi
         echo "Work item linked: $id"
         return
     fi
@@ -2650,6 +2754,44 @@ cmd_diff() {
     local commits
     commits=$(git rev-list --count origin/main..HEAD 2>/dev/null || echo 0)
     echo -e "${GREEN}${commits} commit(s) ahead of main${NC}"
+}
+
+cmd_details() {
+    require_git_context
+    local main_dir="$NOTES_DIR/$NOTE_REPO/main"
+    local details_file="$main_dir/Details.md"
+    local subcmd="${1:-}"
+
+    case "$subcmd" in
+        new)
+            if [[ -f "$details_file" ]]; then
+                echo "Details.md already exists: $details_file"
+                echo "Edit with: bn details edit"
+                return 1
+            fi
+            mkdir -p "$main_dir"
+            _render_template details.md "REPO=$NOTE_REPO" > "$details_file"
+            echo "Created: $details_file"
+            echo "Edit with: bn details edit"
+            ;;
+        edit)
+            if [[ ! -f "$details_file" ]]; then
+                echo "No Details.md for $NOTE_REPO. Create with: bn details new" >&2
+                return 1
+            fi
+            ${EDITOR:-nvim} "$details_file"
+            ;;
+        path) echo "$details_file" ;;
+        "")
+            if [[ -f "$details_file" ]]; then
+                cat "$details_file"
+            else
+                echo "No Details.md for $NOTE_REPO"
+                echo "Create with: bn details new"
+            fi
+            ;;
+        *) echo "Usage: bn details [new|edit|path]" >&2; exit 1 ;;
+    esac
 }
 
 cmd_blog() {
@@ -3192,6 +3334,7 @@ case "${1:-}" in
     diff|d)             cmd_diff ;;
     achieve|ac)         shift; cmd_achieve "$@" ;;
     global|g)           shift; cmd_global "$@" ;;
+    details)            shift; cmd_details "$@" ;;
     blog)               shift; cmd_blog "$@" ;;
     learn)              shift; cmd_learn "$@" ;;
     -h|--help|help)     cmd_help ;;

--- a/.bin/bn
+++ b/.bin/bn
@@ -2876,7 +2876,7 @@ SCRIPTEOF
 
     echo ""
     echo -e "${GREEN}Done.${NC} New branch notes for $NOTE_REPO will auto-include Details.md."
-    echo "Run 'bn build' or 'bn build test' in any worktree to run scripts."
+    echo "Run 'bn build' or 'bn test' in any worktree to run scripts."
 }
 
 cmd_blog() {
@@ -3407,6 +3407,7 @@ case "${1:-}" in
     search)             shift; cmd_search "$@" ;;
     stale)              shift; cmd_stale "$@" ;;
     build|b)            shift; cmd_build "$@" ;;
+    test|t)             cmd_build test ;;
     script|sc)          shift; cmd_script "$@" ;;
     archive)            shift; cmd_archive "$@" ;;
     clean)              shift; cmd_clean "$@" ;;

--- a/.bin/bn
+++ b/.bin/bn
@@ -20,6 +20,7 @@
 #   bn refresh-all|ra               # Refresh all main worktrees
 #   bn main|m                       # Print main note dir + list scripts
 #   bn build|b [name]               # Run a script (default: build)
+#   bn clone                        # Run scripts/clone (e.g. fresh setup / rebase + build + run)
 #   bn run                          # Run 'run' script in background; copies Details.md link
 #   bn cron [list|new|edit|run|setup|teardown|remove]  # Manage branch cron jobs
 #   bn script|sc [new|edit|list]    # Manage repo scripts
@@ -3310,6 +3311,7 @@ Commands:
   refresh-all, ra                 Refresh all main worktrees
   main, m                         Print main note dir + list scripts
   build, b [name]                 Run a script (default: build)
+  clone                           Run scripts/clone (fresh setup, rebase + build + run, etc.)
   run                             Run 'run' script in background; copies Details.md link to clipboard
   script, sc [new|edit|list]      Manage repo scripts
   cron list                       List cron jobs for current repo
@@ -3631,6 +3633,7 @@ case "${1:-}" in
     build|b)            shift; cmd_build "$@" ;;
     run)               cmd_run ;;
     test|t)             cmd_build test ;;
+    clone)             cmd_build clone ;;
     script|sc)          shift; cmd_script "$@" ;;
     archive)            shift; cmd_archive "$@" ;;
     clean)              shift; cmd_clean "$@" ;;

--- a/.bin/bn
+++ b/.bin/bn
@@ -20,6 +20,8 @@
 #   bn refresh-all|ra               # Refresh all main worktrees
 #   bn main|m                       # Print main note dir + list scripts
 #   bn build|b [name]               # Run a script (default: build)
+#   bn run                          # Run 'run' script in background; copies Details.md link
+#   bn cron [list|new|edit|run|setup|teardown|remove]  # Manage branch cron jobs
 #   bn script|sc [new|edit|list]    # Manage repo scripts
 #   bn files|f [name|new|edit]       # Investigation file management
 #   bn archive [--days N] [--dry-run]  # Archive old closed notes
@@ -1992,6 +1994,60 @@ cmd_build() {
     (cd "$work_dir" && "$script")
 }
 
+cmd_run() {
+    require_git_context
+    ensure_scripts_dir "$NOTE_REPO"
+
+    local main_dir="$NOTES_DIR/$NOTE_REPO/main"
+    local details_file="$main_dir/Details.md"
+    if [[ -f "$details_file" ]]; then
+        local url
+        url=$(awk '
+            /^## Links/{found=1; next}
+            /^## /{found=0}
+            found && match($0, /https?:\/\/[^ )]+/) {
+                print substr($0, RSTART, RLENGTH)
+                exit
+            }
+        ' "$details_file")
+        if [[ -n "$url" ]]; then
+            _copy_to_clipboard "$url"
+            echo "Copied to clipboard: $url"
+        fi
+    fi
+
+    local script
+    resolve_script "$NOTE_REPO" "run"; script=$REPLY
+    if [[ ! -f "$script" ]]; then
+        echo "No 'run' script for $NOTE_REPO" >&2
+        echo "Create one with: bn script new run" >&2
+        exit 1
+    fi
+    [[ ! -x "$script" ]] && chmod +x "$script"
+
+    local work_dir log_file pid_file
+    work_dir=$(pwd)
+    log_file="$NOTES_DIR/$NOTE_REPO/$NOTE_BRANCH/run.log"
+    pid_file="$NOTES_DIR/$NOTE_REPO/$NOTE_BRANCH/run.pid"
+
+    if [[ -f "$pid_file" ]]; then
+        local old_pid
+        old_pid=$(cat "$pid_file")
+        if kill -0 "$old_pid" 2>/dev/null; then
+            echo "Stopping previous run (PID $old_pid)..."
+            kill "$old_pid"
+        fi
+        rm -f "$pid_file"
+    fi
+
+    echo "Starting run script in background..."
+    echo "Log: $log_file"
+    (cd "$work_dir" && exec "$script" >> "$log_file" 2>&1) &
+    local pid=$!
+    echo $pid > "$pid_file"
+    echo "PID: $pid"
+}
+
 # Script management: new, edit, list
 cmd_script() {
     local subcmd="${1:-}"
@@ -3057,6 +3113,176 @@ LEARNEOF
     esac
 }
 
+# --- Cron Jobs ---
+
+_crons_dir() { echo "$NOTES_DIR/$1/main/crons"; }
+
+cmd_cron() {
+    local subcmd="${1:-list}"
+    shift 2>/dev/null || true
+    case "$subcmd" in
+        list|l)    _cron_list ;;
+        new)       _cron_new "$@" ;;
+        edit)      _cron_edit "$@" ;;
+        run)       _cron_run "$@" ;;
+        setup)     _cron_setup ;;
+        teardown)  _cron_teardown ;;
+        remove|rm) _cron_remove "$@" ;;
+        *) echo "Usage: bn cron [list|new <name>|edit <name>|run <name>|setup|teardown|remove <name>]" >&2; exit 1 ;;
+    esac
+}
+
+_cron_list() {
+    require_git_context
+    require_yq
+    local crons_dir=$(_crons_dir "$NOTE_REPO")
+    local -a files
+    for f in "$crons_dir"/*.yaml(N); do files+=("$f"); done
+    if (( ${#files[@]} == 0 )); then
+        echo "No crons for $NOTE_REPO — add one with: bn cron new <name>"
+        return
+    fi
+    echo "Crons for $NOTE_REPO:"
+    for f in "${files[@]}"; do
+        local name enabled schedule
+        name=$(yq '.name // ""' "$f")
+        enabled=$(yq '.enabled // true' "$f")
+        schedule=$(yq '.schedule // ""' "$f")
+        local mark="✓"
+        [[ "$enabled" == "false" ]] && mark="✗"
+        printf "  %s  %-22s %s\n" "$mark" "$name" "$schedule"
+    done
+}
+
+_cron_new() {
+    require_git_context
+    require_yq
+    local name="$1"
+    [[ -z "$name" ]] && { echo "Usage: bn cron new <name>" >&2; exit 1; }
+    local crons_dir=$(_crons_dir "$NOTE_REPO")
+    mkdir -p "$crons_dir"
+    local cron_file="$crons_dir/${name}.yaml"
+    if [[ -f "$cron_file" ]]; then
+        echo "Cron '$name' already exists. Edit with: bn cron edit $name" >&2
+        exit 1
+    fi
+    local worktree
+    worktree=$(pwd)
+    cat > "$cron_file" << EOF
+name: $name
+schedule: "0 9 * * *"
+worktree: $worktree
+enabled: true
+steps:
+  - git fetch origin
+  - git rebase origin/main
+  - bn build
+  - bn run
+EOF
+    echo "Created: $cron_file"
+    ${EDITOR:-nvim} "$cron_file"
+}
+
+_cron_edit() {
+    require_git_context
+    local name="$1"
+    local crons_dir=$(_crons_dir "$NOTE_REPO")
+    if [[ -z "$name" ]] && command -v fzf &>/dev/null; then
+        local -a names
+        for f in "$crons_dir"/*.yaml(N); do names+=("${f:t:r}"); done
+        (( ${#names[@]} == 0 )) && { echo "No crons for $NOTE_REPO" >&2; return 1; }
+        name=$(printf '%s\n' "${names[@]}" | fzf --prompt="cron> " --height=10 --no-info 2>/dev/null)
+    fi
+    [[ -z "$name" ]] && { echo "Usage: bn cron edit <name>" >&2; exit 1; }
+    local cron_file="$crons_dir/${name}.yaml"
+    [[ ! -f "$cron_file" ]] && { echo "No cron '$name' for $NOTE_REPO" >&2; exit 1; }
+    ${EDITOR:-nvim} "$cron_file"
+}
+
+_cron_run() {
+    local name="" repo=""
+    while [[ -n "${1:-}" ]]; do
+        case "$1" in
+            --repo) repo="$2"; shift 2 ;;
+            *)      [[ -z "$name" ]] && name="$1"; shift ;;
+        esac
+    done
+    if [[ -n "$repo" ]]; then
+        NOTE_REPO="$repo"
+    else
+        require_git_context
+    fi
+    [[ -z "$name" ]] && { echo "Usage: bn cron run <name> [--repo <repo>]" >&2; exit 1; }
+    require_yq
+    local crons_dir=$(_crons_dir "$NOTE_REPO")
+    local cron_file="$crons_dir/${name}.yaml"
+    [[ ! -f "$cron_file" ]] && { echo "No cron '$name' for $NOTE_REPO" >&2; exit 1; }
+
+    local worktree enabled
+    worktree=$(yq '.worktree // ""' "$cron_file")
+    enabled=$(yq '.enabled // true' "$cron_file")
+    [[ "$enabled" == "false" ]] && { echo "Cron '$name' is disabled" >&2; exit 1; }
+    [[ -z "$worktree" || ! -d "$worktree" ]] && { echo "Worktree not found: $worktree" >&2; exit 1; }
+
+    echo "Running cron '$name' in $worktree..."
+    local step_count i step
+    step_count=$(yq '.steps | length' "$cron_file")
+    for (( i = 0; i < step_count; i++ )); do
+        step=$(yq ".steps[$i]" "$cron_file")
+        echo "  → $step"
+        (cd "$worktree" && eval "$step") || { echo "  ✗ Failed: $step" >&2; exit 1; }
+    done
+    echo "  ✓ Done"
+}
+
+_cron_setup() {
+    require_git_context
+    require_yq
+    local crons_dir=$(_crons_dir "$NOTE_REPO")
+    local bn_path="$HOME/.bin/bn"
+    local -a new_lines
+    for f in "$crons_dir"/*.yaml(N); do
+        local name enabled schedule
+        name=$(yq '.name // ""' "$f")
+        enabled=$(yq '.enabled // true' "$f")
+        schedule=$(yq '.schedule // ""' "$f")
+        [[ "$enabled" == "false" || -z "$name" || -z "$schedule" ]] && continue
+        new_lines+=("$schedule $bn_path cron run $name --repo $NOTE_REPO")
+    done
+    local current stripped
+    current=$(crontab -l 2>/dev/null || true)
+    stripped=$(printf '%s\n' "$current" | awk "/^# BEGIN bn:${NOTE_REPO}\$/{skip=1;next} /^# END bn:${NOTE_REPO}\$/{skip=0;next} !skip{print}")
+    local new_ct="$stripped"
+    if (( ${#new_lines[@]} > 0 )); then
+        new_ct+=$'\n'"# BEGIN bn:$NOTE_REPO"
+        for line in "${new_lines[@]}"; do new_ct+=$'\n'"$line"; done
+        new_ct+=$'\n'"# END bn:$NOTE_REPO"
+    fi
+    printf '%s\n' "$new_ct" | crontab -
+    echo "Installed ${#new_lines[@]} cron job(s) for $NOTE_REPO:"
+    for line in "${new_lines[@]}"; do echo "  $line"; done
+}
+
+_cron_teardown() {
+    require_git_context
+    local current stripped
+    current=$(crontab -l 2>/dev/null || true)
+    stripped=$(printf '%s\n' "$current" | awk "/^# BEGIN bn:${NOTE_REPO}\$/{skip=1;next} /^# END bn:${NOTE_REPO}\$/{skip=0;next} !skip{print}")
+    printf '%s\n' "$stripped" | crontab -
+    echo "Removed cron entries for $NOTE_REPO"
+}
+
+_cron_remove() {
+    require_git_context
+    local name="$1"
+    [[ -z "$name" ]] && { echo "Usage: bn cron remove <name>" >&2; exit 1; }
+    local crons_dir=$(_crons_dir "$NOTE_REPO")
+    local cron_file="$crons_dir/${name}.yaml"
+    [[ ! -f "$cron_file" ]] && { echo "No cron '$name' for $NOTE_REPO" >&2; exit 1; }
+    rm "$cron_file"
+    echo "Removed cron '$name'"
+}
+
 cmd_help() {
     cat << 'HELPEOF'
 Usage: bn [command]
@@ -3084,7 +3310,15 @@ Commands:
   refresh-all, ra                 Refresh all main worktrees
   main, m                         Print main note dir + list scripts
   build, b [name]                 Run a script (default: build)
+  run                             Run 'run' script in background; copies Details.md link to clipboard
   script, sc [new|edit|list]      Manage repo scripts
+  cron list                       List cron jobs for current repo
+  cron new <name>                 Create a cron job (opens editor)
+  cron edit <name>                Edit a cron job
+  cron run <name> [--repo <r>]    Run a cron job's steps immediately
+  cron setup                      Install enabled crons into system crontab
+  cron teardown                   Remove this repo's crons from crontab
+  cron remove <name>              Delete a cron job
   files, f                        List investigation files in current branch
   files <name>                    Print contents of investigation file
   files new <name>                Create new investigation file
@@ -3395,6 +3629,7 @@ case "${1:-}" in
     search)             shift; cmd_search "$@" ;;
     stale)              shift; cmd_stale "$@" ;;
     build|b)            shift; cmd_build "$@" ;;
+    run)               cmd_run ;;
     test|t)             cmd_build test ;;
     script|sc)          shift; cmd_script "$@" ;;
     archive)            shift; cmd_archive "$@" ;;
@@ -3412,6 +3647,7 @@ case "${1:-}" in
     details)            shift; cmd_details "$@" ;;
     blog)               shift; cmd_blog "$@" ;;
     learn)              shift; cmd_learn "$@" ;;
+    cron)               shift; cmd_cron "$@" ;;
     -h|--help|help)     cmd_help ;;
     "")                 cmd_default ;;
     *)                  echo "Unknown command: $1" >&2; exit 1 ;;

--- a/.bin/bn
+++ b/.bin/bn
@@ -1969,23 +1969,11 @@ cmd_main() {
     fi
 }
 
-# Run a named script (default: build). No name → tries "build", then fzf.
+# Run a named script (default: build).
 cmd_build() {
-    local name="${1:-}"
+    local name="${1:-build}"
     require_git_context
     ensure_scripts_dir "$NOTE_REPO"
-
-    if [[ -z "$name" ]]; then
-        local default_script; resolve_script "$NOTE_REPO" "build"; default_script=$REPLY
-        if [[ -f "$default_script" ]]; then
-            name="build"
-        elif command -v fzf &>/dev/null && _fzf_pick_script "$NOTE_REPO"; then
-            name="$REPLY"
-        else
-            echo "No scripts for $NOTE_REPO. Create one with: bn script new <name>" >&2
-            exit 1
-        fi
-    fi
 
     local script
     resolve_script "$NOTE_REPO" "$name"; script=$REPLY

--- a/.bin/bn
+++ b/.bin/bn
@@ -47,7 +47,7 @@ fi
 
 # --- Config ---
 
-NOTES_DIR="$HOME/projects/worktree/personal-notes/branch-notes/branch-notes"
+NOTES_DIR="$HOME/projects/branch-notes"
 _HOSTNAME=$(hostname)
 
 # --- Helpers: Git Context ---

--- a/.bin/bn
+++ b/.bin/bn
@@ -20,7 +20,6 @@
 #   bn refresh-all|ra               # Refresh all main worktrees
 #   bn main|m                       # Print main note dir + list scripts
 #   bn build|b [name]               # Run a script (default: build)
-#   bn clone                        # Run scripts/clone (e.g. fresh setup / rebase + build + run)
 #   bn run                          # Run 'run' script in background; copies Details.md link
 #   bn cron [list|new|edit|run|setup|teardown|remove]  # Manage branch cron jobs
 #   bn script|sc [new|edit|list]    # Manage repo scripts
@@ -3311,7 +3310,6 @@ Commands:
   refresh-all, ra                 Refresh all main worktrees
   main, m                         Print main note dir + list scripts
   build, b [name]                 Run a script (default: build)
-  clone                           Run scripts/clone (fresh setup, rebase + build + run, etc.)
   run                             Run 'run' script in background; copies Details.md link to clipboard
   script, sc [new|edit|list]      Manage repo scripts
   cron list                       List cron jobs for current repo
@@ -3633,7 +3631,6 @@ case "${1:-}" in
     build|b)            shift; cmd_build "$@" ;;
     run)               cmd_run ;;
     test|t)             cmd_build test ;;
-    clone)             cmd_build clone ;;
     script|sc)          shift; cmd_script "$@" ;;
     archive)            shift; cmd_archive "$@" ;;
     clean)              shift; cmd_clean "$@" ;;

--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -87,6 +87,12 @@ detect_distro() {
 # Repos that get regular (non-bare) clones at ~/projects/reponame
 REGULAR_CLONE_REPOS=(dotfiles nvim personal-notes eduuh)
 
+# Repos that should live on the Windows filesystem when on WSL
+# (cloned to /mnt/c/projects/<name>, symlinked at ~/projects/<name>)
+WINDOWS_CLONE_REPOS=(personal-notes)
+
+WINDOWS_PROJECTS_DIR="/mnt/c/projects"
+
 _is_regular_repo() {
     local name="$1"
     for r in "${REGULAR_CLONE_REPOS[@]}"; do
@@ -95,14 +101,39 @@ _is_regular_repo() {
     return 1
 }
 
+_is_wsl() {
+    grep -qi microsoft /proc/version 2>/dev/null
+}
+
+_is_windows_repo() {
+    local name="$1"
+    _is_wsl || return 1
+    for r in "${WINDOWS_CLONE_REPOS[@]}"; do
+        [[ "$name" == "$r" ]] && return 0
+    done
+    return 1
+}
+
+# Resolve the on-disk path a regular clone should live at, honoring WSL→Windows rules
+_regular_clone_target() {
+    local name="$1"
+    if _is_windows_repo "$name"; then
+        echo "$WINDOWS_PROJECTS_DIR/$name"
+    else
+        echo "$HOME/projects/$name"
+    fi
+}
+
 _clone_single_repo() {
     local REPO="$1"
     local REPO_NAME=$(basename "$REPO" .git)
 
     if _is_regular_repo "$REPO_NAME"; then
-        local CLONE_DIR=~/projects/"$REPO_NAME"
+        local CLONE_DIR
+        CLONE_DIR=$(_regular_clone_target "$REPO_NAME")
+        local SYMLINK_DIR=~/projects/"$REPO_NAME"
 
-        if [ -d "$CLONE_DIR" ]; then
+        if [ -d "$CLONE_DIR" ] && [ ! -L "$CLONE_DIR" ]; then
             if [ -d "$CLONE_DIR/.git" ]; then
                 cd "$CLONE_DIR"
                 if ! git diff --quiet || ! git diff --cached --quiet; then
@@ -116,8 +147,20 @@ _clone_single_repo() {
                 echo "[$REPO_NAME] Directory exists but is not a git repo. Skipping."
             fi
         else
-            echo "[$REPO_NAME] Cloning (regular)..."
+            if _is_windows_repo "$REPO_NAME"; then
+                mkdir -p "$WINDOWS_PROJECTS_DIR" || { echo "[$REPO_NAME] Failed to create $WINDOWS_PROJECTS_DIR."; return 1; }
+            fi
+            echo "[$REPO_NAME] Cloning (regular) → $CLONE_DIR..."
             git clone "$REPO" "$CLONE_DIR" || { echo "[$REPO_NAME] Failed to clone."; return 1; }
+            # Disable filemode tracking on /mnt/c (NTFS) to avoid spurious 'mode changed' diffs
+            if _is_windows_repo "$REPO_NAME"; then
+                git -C "$CLONE_DIR" config core.filemode false
+            fi
+        fi
+
+        # Symlink ~/projects/<name> → $CLONE_DIR if cloned to a non-default location
+        if [ "$CLONE_DIR" != "$SYMLINK_DIR" ] && [ ! -e "$SYMLINK_DIR" ]; then
+            ln -s "$CLONE_DIR" "$SYMLINK_DIR" && echo "[$REPO_NAME] Symlinked $SYMLINK_DIR → $CLONE_DIR"
         fi
 
         # Special handling for Neovim config
@@ -155,6 +198,35 @@ _clone_single_repo() {
             cd ~
         fi
     fi
+}
+
+# Ensure the branch-notes repo exists on Windows (WSL only) and is symlinked
+# at the path `bn` expects: ~/projects/branch-notes
+setup_branch_notes_symlink() {
+    _is_wsl || return 0
+
+    local target="$WINDOWS_PROJECTS_DIR/branch-notes"
+    local link="$HOME/projects/branch-notes"
+
+    mkdir -p "$WINDOWS_PROJECTS_DIR" || { track_failure "branch-notes" "Failed to create $WINDOWS_PROJECTS_DIR"; return 1; }
+
+    if [ ! -d "$target/.git" ]; then
+        echo "[branch-notes] Initializing repo at $target..."
+        mkdir -p "$target"
+        (cd "$target" && git init -b main >/dev/null && git config core.filemode false) || {
+            track_failure "branch-notes" "Failed to git init $target"
+            return 1
+        }
+    fi
+
+    if [ -L "$link" ]; then
+        return 0
+    fi
+    if [ -e "$link" ]; then
+        track_failure "branch-notes" "$link exists and is not a symlink — refusing to overwrite"
+        return 1
+    fi
+    ln -s "$target" "$link" && echo "[branch-notes] Symlinked $link → $target"
 }
 
 clone_repos() {
@@ -207,6 +279,8 @@ clone_repos() {
     done
     wait
     echo "All repository clones finished."
+
+    setup_branch_notes_symlink
 }
 
 ensure_tmux_version() {
@@ -606,7 +680,7 @@ setup_symlinks() {
 }
 
 setup_personal_notes_stow() {
-    local stow_dir=~/projects/worktree/personal-notes/main/stow
+    local stow_dir=~/projects/personal-notes/stow
 
     if [ ! -d "$stow_dir" ]; then
         echo "personal-notes stow directory not found at $stow_dir — skipping."

--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -214,23 +214,23 @@ _clone_single_repo() {
     fi
 }
 
-# Ensure the branch-notes repo exists on Windows (WSL only) and is symlinked
-# at the path `bn` expects: ~/projects/branch-notes
-setup_branch_notes_symlink() {
-    _is_wsl || return 0
+# Provision one branch-notes-style repo on Windows + symlink under ~/projects/.
+# Used for both the personal `branch-notes` repo and the `branch-notes-work` repo
+# for work-classified projects (allowlist in ~/.config/bn/work-repos).
+_setup_one_branch_notes_repo() {
+    local name="$1"
+    local win_dir target link
+    win_dir=$(_windows_projects_dir) || { track_failure "$name" "Could not resolve Windows projects dir"; return 1; }
+    target="$win_dir/$name"
+    link="$HOME/projects/$name"
 
-    local win_dir
-    win_dir=$(_windows_projects_dir) || { track_failure "branch-notes" "Could not resolve Windows projects dir"; return 1; }
-    local target="$win_dir/branch-notes"
-    local link="$HOME/projects/branch-notes"
-
-    mkdir -p "$win_dir" || { track_failure "branch-notes" "Failed to create $win_dir"; return 1; }
+    mkdir -p "$win_dir" || { track_failure "$name" "Failed to create $win_dir"; return 1; }
 
     if [ ! -d "$target/.git" ]; then
-        echo "[branch-notes] Initializing repo at $target..."
+        echo "[$name] Initializing repo at $target..."
         mkdir -p "$target"
         (cd "$target" && git init -b main >/dev/null && git config core.filemode false) || {
-            track_failure "branch-notes" "Failed to git init $target"
+            track_failure "$name" "Failed to git init $target"
             return 1
         }
     fi
@@ -239,10 +239,18 @@ setup_branch_notes_symlink() {
         return 0
     fi
     if [ -e "$link" ]; then
-        track_failure "branch-notes" "$link exists and is not a symlink — refusing to overwrite"
+        track_failure "$name" "$link exists and is not a symlink — refusing to overwrite"
         return 1
     fi
-    ln -s "$target" "$link" && echo "[branch-notes] Symlinked $link → $target"
+    ln -s "$target" "$link" && echo "[$name] Symlinked $link → $target"
+}
+
+# Provision both branch-notes repos (personal + work). bn picks the right one
+# per repo via $HOME/.config/bn/work-repos (allowlist, gitignored).
+setup_branch_notes_symlink() {
+    _is_wsl || return 0
+    _setup_one_branch_notes_repo "branch-notes"
+    _setup_one_branch_notes_repo "branch-notes-work"
 }
 
 clone_repos() {

--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -88,10 +88,8 @@ detect_distro() {
 REGULAR_CLONE_REPOS=(dotfiles nvim personal-notes eduuh)
 
 # Repos that should live on the Windows filesystem when on WSL
-# (cloned to /mnt/c/projects/<name>, symlinked at ~/projects/<name>)
+# (cloned to $WINDOWS_PROJECTS_DIR/<name>, symlinked at ~/projects/<name>)
 WINDOWS_CLONE_REPOS=(personal-notes)
-
-WINDOWS_PROJECTS_DIR="/mnt/c/projects"
 
 _is_regular_repo() {
     local name="$1"
@@ -103,6 +101,20 @@ _is_regular_repo() {
 
 _is_wsl() {
     grep -qi microsoft /proc/version 2>/dev/null
+}
+
+# Resolve the Windows-side `projects` directory under the current Windows user's
+# profile (e.g. /mnt/c/Users/<user>/projects). Computed lazily so non-WSL hosts
+# don't pay the cmd.exe round-trip.
+_windows_projects_dir() {
+    if [ -z "$WINDOWS_PROJECTS_DIR" ]; then
+        _is_wsl || return 1
+        local userprofile
+        userprofile=$(/mnt/c/Windows/System32/cmd.exe /c "echo %USERPROFILE%" 2>/dev/null | tr -d '\r\n')
+        [ -z "$userprofile" ] && return 1
+        WINDOWS_PROJECTS_DIR="$(wslpath "$userprofile" 2>/dev/null)/projects"
+    fi
+    echo "$WINDOWS_PROJECTS_DIR"
 }
 
 _is_windows_repo() {
@@ -118,7 +130,7 @@ _is_windows_repo() {
 _regular_clone_target() {
     local name="$1"
     if _is_windows_repo "$name"; then
-        echo "$WINDOWS_PROJECTS_DIR/$name"
+        echo "$(_windows_projects_dir)/$name"
     else
         echo "$HOME/projects/$name"
     fi
@@ -148,7 +160,9 @@ _clone_single_repo() {
             fi
         else
             if _is_windows_repo "$REPO_NAME"; then
-                mkdir -p "$WINDOWS_PROJECTS_DIR" || { echo "[$REPO_NAME] Failed to create $WINDOWS_PROJECTS_DIR."; return 1; }
+                local win_dir
+                win_dir=$(_windows_projects_dir) || { echo "[$REPO_NAME] Could not resolve Windows projects dir."; return 1; }
+                mkdir -p "$win_dir" || { echo "[$REPO_NAME] Failed to create $win_dir."; return 1; }
             fi
             echo "[$REPO_NAME] Cloning (regular) → $CLONE_DIR..."
             git clone "$REPO" "$CLONE_DIR" || { echo "[$REPO_NAME] Failed to clone."; return 1; }
@@ -205,10 +219,12 @@ _clone_single_repo() {
 setup_branch_notes_symlink() {
     _is_wsl || return 0
 
-    local target="$WINDOWS_PROJECTS_DIR/branch-notes"
+    local win_dir
+    win_dir=$(_windows_projects_dir) || { track_failure "branch-notes" "Could not resolve Windows projects dir"; return 1; }
+    local target="$win_dir/branch-notes"
     local link="$HOME/projects/branch-notes"
 
-    mkdir -p "$WINDOWS_PROJECTS_DIR" || { track_failure "branch-notes" "Failed to create $WINDOWS_PROJECTS_DIR"; return 1; }
+    mkdir -p "$win_dir" || { track_failure "branch-notes" "Failed to create $win_dir"; return 1; }
 
     if [ ! -d "$target/.git" ]; then
         echo "[branch-notes] Initializing repo at $target..."

--- a/.bin/tmux/branch-note-status.sh
+++ b/.bin/tmux/branch-note-status.sh
@@ -7,7 +7,18 @@ source "$HOME/.bin/tmux/tmux-lib.sh"
 
 resolve_note_context "${1:-$(pwd)}" || exit 0
 
-note_dir="$HOME/projects/branch-notes/$NOTE_REPO/$NOTE_BRANCH"
+# Match bn's WORK_REPOS allowlist so the status badge reads from the right repo.
+work_repos_file="${BN_WORK_REPOS_FILE:-$HOME/.config/bn/work-repos}"
+notes_dir="$HOME/projects/branch-notes"
+if [[ -r "$work_repos_file" ]]; then
+    while IFS= read -r line; do
+        line="${line%%#*}"
+        line="${line//[[:space:]]/}"
+        [[ "$line" == "$NOTE_REPO" ]] && { notes_dir="$HOME/projects/branch-notes-work"; break; }
+    done < "$work_repos_file"
+fi
+
+note_dir="$notes_dir/$NOTE_REPO/$NOTE_BRANCH"
 note="$note_dir/note.md"
 yaml="$note_dir/note.yaml"
 [[ -f "$note" ]] || exit 0

--- a/.bin/tmux/branch-note-status.sh
+++ b/.bin/tmux/branch-note-status.sh
@@ -7,7 +7,7 @@ source "$HOME/.bin/tmux/tmux-lib.sh"
 
 resolve_note_context "${1:-$(pwd)}" || exit 0
 
-note_dir="$HOME/projects/worktree/personal-notes/branch-notes/branch-notes/$NOTE_REPO/$NOTE_BRANCH"
+note_dir="$HOME/projects/branch-notes/$NOTE_REPO/$NOTE_BRANCH"
 note="$note_dir/note.md"
 yaml="$note_dir/note.yaml"
 [[ -f "$note" ]] || exit 0

--- a/.bin/tmux/branch-note-status.sh
+++ b/.bin/tmux/branch-note-status.sh
@@ -7,12 +7,19 @@ source "$HOME/.bin/tmux/tmux-lib.sh"
 
 resolve_note_context "${1:-$(pwd)}" || exit 0
 
-note="$HOME/projects/worktree/personal-notes/branch-notes/branch-notes/$NOTE_REPO/$NOTE_BRANCH/note.md"
+note_dir="$HOME/projects/worktree/personal-notes/branch-notes/branch-notes/$NOTE_REPO/$NOTE_BRANCH"
+note="$note_dir/note.md"
+yaml="$note_dir/note.yaml"
 [[ -f "$note" ]] || exit 0
 
-# Skip closed notes
-note_status=$(sed -n '/^---$/,/^---$/{ /^status:/s/^status: *//p; }' "$note")
-[[ "$note_status" == "closed" ]] && exit 0
+if [[ -f "$yaml" ]]; then
+    note_status=$(yq -r '.status // "active"' "$yaml" 2>/dev/null)
+    [[ "$note_status" == "closed" ]] && exit 0
+    count=$(yq -r '[.todos[] | select(.done != true)] | length' "$yaml" 2>/dev/null)
+else
+    note_status=$(sed -n '/^---$/,/^---$/{ /^status:/s/^status: *//p; }' "$note")
+    [[ "$note_status" == "closed" ]] && exit 0
+    count=$(grep -c '^\- \[ \]' "$note" 2>/dev/null)
+fi
 
-count=$(grep -c '^\- \[ \]' "$note" 2>/dev/null)
 (( count > 0 )) && echo " TODO[$count]"

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,9 +1,9 @@
 [credential "https://github.com"]
 	helper = 
-	helper = !/opt/homebrew/bin/gh auth git-credential
+	helper = !/home/edd/.local/bin/gh auth git-credential
 [credential "https://gist.github.com"]
 	helper = 
-	helper = !/opt/homebrew/bin/gh auth git-credential
+	helper = !/home/edd/.local/bin/gh auth git-credential
 [user]
 	name = eduuh
 	email = 31909722+eduuh@users.noreply.github.com


### PR DESCRIPTION
## Summary
Syncs ~9 local bn improvements that accumulated on main plus introduces the new Windows-filesystem migration for personal-notes & branch-notes.

## Notes-on-Windows migration
On WSL, personal-notes and branch-notes now live on the Windows filesystem with thin symlinks back to ~/projects/. Setup wires this up automatically via WINDOWS_CLONE_REPOS + setup_branch_notes_symlink(). Cloned repos get core.filemode=false to silence NTFS permission churn.

## Test plan
- [ ] Fresh WSL install replicates the Windows-fs layout
- [ ] bn --path, bn --cat, bn add work through ~/projects/branch-notes
- [ ] Tmux branch-note-status badge renders with the updated path

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>