### PR TITLE
feat: clone branch-notes-work + simplify new tat sessions

### DIFF
--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -217,8 +217,13 @@ _clone_single_repo() {
 # Provision one branch-notes-style repo on Windows + symlink under ~/projects/.
 # Used for both the personal `branch-notes` repo and the `branch-notes-work` repo
 # for work-classified projects (allowlist in ~/.config/bn/work-repos).
+#
+# Usage: _setup_one_branch_notes_repo <name> [remote_url]
+# If a remote URL is provided and the target has no .git yet, the repo is
+# cloned from it. Otherwise the target is initialized as an empty repo.
 _setup_one_branch_notes_repo() {
     local name="$1"
+    local remote="$2"
     local win_dir target link
     win_dir=$(_windows_projects_dir) || { track_failure "$name" "Could not resolve Windows projects dir"; return 1; }
     target="$win_dir/$name"
@@ -227,12 +232,21 @@ _setup_one_branch_notes_repo() {
     mkdir -p "$win_dir" || { track_failure "$name" "Failed to create $win_dir"; return 1; }
 
     if [ ! -d "$target/.git" ]; then
-        echo "[$name] Initializing repo at $target..."
-        mkdir -p "$target"
-        (cd "$target" && git init -b main >/dev/null && git config core.filemode false) || {
-            track_failure "$name" "Failed to git init $target"
-            return 1
-        }
+        if [ -n "$remote" ]; then
+            echo "[$name] Cloning from $remote → $target..."
+            git clone "$remote" "$target" || {
+                track_failure "$name" "Failed to clone $remote"
+                return 1
+            }
+            git -C "$target" config core.filemode false
+        else
+            echo "[$name] Initializing repo at $target..."
+            mkdir -p "$target"
+            (cd "$target" && git init -b main >/dev/null && git config core.filemode false) || {
+                track_failure "$name" "Failed to git init $target"
+                return 1
+            }
+        fi
     fi
 
     if [ -L "$link" ]; then
@@ -305,21 +319,22 @@ clone_repos() {
     echo "All repository clones finished."
 
     setup_branch_notes_symlink
-    _clone_work_repos_from_personal_notes
+    _run_work_setup_from_personal_notes
 }
 
-# After personal repos are cloned, source a work-repo clone script from
-# personal-notes if it exists. The script defines a WORK_REPOS array (or
-# calls _clone_single_repo directly) so the list of work repos stays in
-# the private personal-notes repo instead of this public dotfiles repo.
-_clone_work_repos_from_personal_notes() {
-    local work_script="${WORK_CLONE_SCRIPT:-$HOME/projects/personal-notes/scripts/clone-work.sh}"
+# After personal repos are cloned, source a work-repo setup script from
+# personal-notes if it exists. The script defines a WORK_REPOS array, calls
+# _clone_single_repo, and/or calls _setup_one_branch_notes_repo with a remote
+# URL — so the list of work repos and their URLs stay in the private
+# personal-notes repo instead of this public dotfiles repo.
+_run_work_setup_from_personal_notes() {
+    local work_script="${WORK_SETUP_SCRIPT:-$HOME/projects/personal-notes/scripts/setup-work-repos.sh}"
     if [[ ! -f "$work_script" ]]; then
         return 0
     fi
-    echo "Sourcing work clone script: $work_script"
+    echo "Sourcing work setup script: $work_script"
     source "$work_script"
-    echo "Work repo clones finished."
+    echo "Work repo setup finished."
 }
 
 ensure_tmux_version() {

--- a/.bin/tmux/tat-template.sh
+++ b/.bin/tmux/tat-template.sh
@@ -17,7 +17,5 @@ fi
 
 command -v zoxide &>/dev/null && zoxide add "$start_path"
 
-$TMUX_CMD new-session -d -s "$session_name" -n main -c "$start_path" \
-    "zsh -ic 'claude --dangerously-skip-permissions'"
-$TMUX_CMD split-window -h -t "${session_name}:main" -c "$start_path"
+$TMUX_CMD new-session -d -s "$session_name" -n main -c "$start_path"
 $TMUX_CMD switch-client -t "$session_name"


### PR DESCRIPTION
## Summary
- Extend `_setup_one_branch_notes_repo` in `.bin/setup/common.sh` so it can `git clone` from an optional remote URL (instead of `git init`). Existing `branch-notes` behavior is unchanged when no URL is passed.
- Rename the work-setup hook to look for `personal-notes/scripts/setup-work-repos.sh` (was `clone-work.sh`) so the work URL list stays in the private repo. Env var `WORK_SETUP_SCRIPT` overrides the path.
- Drop the implicit `claude --dangerously-skip-permissions` + vertical split from new tmux sessions created by `tat` — sessions now open as a single shell pane in the project's start path. Worktree-window helper (`open_worktree_window`) is unchanged.

## Test plan
- [ ] Fresh `setup-projects.sh` run on WSL clones `branch-notes-work` from the private remote and symlinks it at `~/projects/branch-notes-work`.
- [ ] `tat <project>` opens a single shell pane in the project's path with no claude process auto-started.