### PR TITLE
feat(bn): bn-sync sidecar + route 'bn sync' to it

### DIFF
--- a/.bin/bn-sync
+++ b/.bin/bn-sync
@@ -1,0 +1,79 @@
+#!/usr/bin/env zsh
+# bn-sync — commit + push pending changes in the branch-notes repo.
+#
+# bn writes notes directly to disk; this is the missing "sync to remote" step
+# that the CLAUDE.md docs promise. Safe to run any time: no-ops when the
+# working tree is clean.
+#
+# Usage:
+#   bn-sync               # commit + push
+#   bn-sync --dry-run     # show what would be committed, don't do it
+#   bn-sync -m "msg"      # override the auto-generated commit message
+#
+# The auto-generated message lists the changed paths, mirroring the prior
+# "chore(bn): sync [path1,path2]" convention.
+
+set -e
+
+notes_dir="${HOME}/projects/branch-notes"
+
+if [[ ! -d "$notes_dir/.git" ]]; then
+    print -u2 "bn-sync: $notes_dir is not a git repo. Run 'git init' there first."
+    exit 1
+fi
+
+dry_run=false
+custom_msg=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run|-n) dry_run=true; shift ;;
+        -m|--message)  custom_msg="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) print -u2 "bn-sync: unknown arg '$1'"; exit 2 ;;
+    esac
+done
+
+cd "$notes_dir"
+
+# Snapshot what changed before we stage. `git status -s` lists modified +
+# untracked together; trim status flags down to the bare paths for the
+# commit-message manifest.
+changed=$(git status -s | awk '{ $1=""; sub(/^ +/, ""); print }')
+
+if [[ -z "$changed" ]]; then
+    echo "bn-sync: nothing to commit"
+    exit 0
+fi
+
+count=$(printf '%s\n' "$changed" | wc -l | tr -d ' ')
+manifest=$(printf '%s\n' "$changed" | paste -sd ',' -)
+
+if $dry_run; then
+    echo "bn-sync: would commit $count file(s):"
+    printf '  %s\n' "${(@f)changed}"
+    exit 0
+fi
+
+git add -A
+
+if [[ -n "$custom_msg" ]]; then
+    msg="$custom_msg"
+else
+    msg="chore(bn): sync [$manifest]"
+fi
+
+git commit -m "$msg" >/dev/null
+
+# Push to whatever remote 'main' (or current branch) tracks. Quiet on
+# success; surface output on failure so the user sees auth errors etc.
+if ! out=$(git push 2>&1); then
+    print -u2 "bn-sync: push failed:"
+    print -u2 "$out"
+    exit 1
+fi
+
+echo "bn-sync: pushed $count file(s)"

--- a/.zshrc
+++ b/.zshrc
@@ -24,7 +24,17 @@ alias l='ls -CF'
 alias yolo='claude --dangerously-skip-permissions'
 alias po="$HOME/.bin/pkg-open.sh"
 alias nvimd='nvim -c "DiffviewOpen origin/main"'
-alias bn="$HOME/.bin/bn"
+# Wrap bn so `bn sync` routes to the sidecar script — the underlying bn
+# binary doesn't implement a sync subcommand, but CLAUDE.md (and muscle
+# memory) treat it as one. All other subcommands pass straight through.
+bn() {
+    if [[ "$1" == "sync" ]]; then
+        shift
+        "$HOME/.bin/bn-sync" "$@"
+    else
+        "$HOME/.bin/bn" "$@"
+    fi
+}
 
 # Load NVM
 export NVM_DIR="$HOME/.nvm"
@@ -32,6 +42,9 @@ export NVM_DIR="$HOME/.nvm"
 
 # Load Cargo
 [ -f "$HOME/.cargo/env" ] && source "$HOME/.cargo/env"
+
+# Helix runtime (manual Linux install; brew/macOS manages its own)
+[ -d "$HOME/.local/share/helix/runtime" ] && export HELIX_RUNTIME="$HOME/.local/share/helix/runtime"
 
 # Load FZF
 [ -f "$HOME/.fzf.zsh" ] && source "$HOME/.fzf.zsh"


### PR DESCRIPTION
## Summary

- `bin/bn-sync` — sidecar script that stages, commits (`chore(bn): sync [paths]`), and pushes whatever's pending under `~/projects/branch-notes`. No-op when clean, `--dry-run` previews the manifest, `-m` overrides the auto-message.
- `.zshrc` — replaces the `alias bn=$HOME/.bin/bn` line with a wrapper function that intercepts the `sync` subcommand and forwards to `bn-sync`. Everything else passes through to the bn binary untouched.

## Why

CLAUDE.md (and muscle memory) treat `bn sync` as the way to flush local note changes to the remote, but the bn binary doesn't actually implement that subcommand — it errors out with "Unknown command: sync". This closes that gap without modifying the binary.

## Test plan

- [ ] In a clean tree: `bn sync` reports "nothing to commit"
- [ ] After `bn add todo "x"`: `bn sync --dry-run` lists the changed `note.md` / `note.yaml`
- [ ] `bn sync` actually commits and pushes
- [ ] Every other `bn <subcommand>` still works (regression check on `bn --cat`, `bn todo`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)