### PR TITLE
fix(setup): recurse submodules on bootstrap clone + update

### DIFF
--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -153,6 +153,7 @@ _clone_single_repo() {
                 else
                     echo "[$REPO_NAME] Updating..."
                     git pull origin "$(git symbolic-ref --short HEAD)" || echo "[$REPO_NAME] Failed to pull."
+                    git submodule update --init --recursive || echo "[$REPO_NAME] Failed to update submodules."
                 fi
                 cd ~
             else
@@ -165,7 +166,7 @@ _clone_single_repo() {
                 mkdir -p "$win_dir" || { echo "[$REPO_NAME] Failed to create $win_dir."; return 1; }
             fi
             echo "[$REPO_NAME] Cloning (regular) → $CLONE_DIR..."
-            git clone "$REPO" "$CLONE_DIR" || { echo "[$REPO_NAME] Failed to clone."; return 1; }
+            git clone --recurse-submodules "$REPO" "$CLONE_DIR" || { echo "[$REPO_NAME] Failed to clone."; return 1; }
             # Disable filemode tracking on /mnt/c (NTFS) to avoid spurious 'mode changed' diffs
             if _is_windows_repo "$REPO_NAME"; then
                 git -C "$CLONE_DIR" config core.filemode false


### PR DESCRIPTION
A fresh bootstrap ran `git clone` without `--recurse-submodules`, so a new machine got an **empty** `.bin/bn-repo` and `.bin/tmux-workflow` — dangling `bn` symlink and dead tmux bindings. And `git pull` on an existing checkout never advanced submodule pins.

## Fix
- `--recurse-submodules` on the regular clone
- `git submodule update --init --recursive` after pull

## Verified
Fresh recursive clone of dotfiles into a temp dir populated both submodules — `bn`, `tat`, and `tmux.conf` all present at the pinned commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)