### PR TITLE
fix(wt): drop source of retired tmux-lib.sh (wt was broken)

### DIFF
--- a/.bin/wt
+++ b/.bin/wt
@@ -5,8 +5,6 @@
 
 set -e
 
-source "$HOME/.bin/tmux/tmux-lib.sh"
-
 # Repositories that should NOT be cloned as bare (regular clone instead)
 # These repos will be cloned to ~/projects/reponame (without .git suffix)
 REGULAR_CLONE_REPOS=(


### PR DESCRIPTION
Regression from the tmux-workflow migration: retiring `~/.bin/tmux/` broke `wt`, which (being extensionless) escaped the reference grep and still `source`d the deleted `tmux-lib.sh` — aborting on every run under `set -e`.

The source was **vestigial**: `wt` uses nothing from the lib (defines its own `sanitize_branch`). Removed the line.

## Verified
`zsh -n` clean; `wt list` runs (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)