### PR TITLE
fix(setup): don't install neovim in codespaces

### DIFF
--- a/.bin/setup/ubuntu.sh
+++ b/.bin/setup/ubuntu.sh
@@ -167,7 +167,6 @@ setup_codespace() {
     update_system
     install_common_packages
     ensure_tmux_version
-    install_neovim
     install_fzf
     install_claude_code
     setup_python


### PR DESCRIPTION
Codespaces use their own editor (VS Code web); a terminal nvim binary there is unused setup overhead. `setup_codespace` no longer calls `install_neovim`, and the codespace clone list already omits the nvim config — so codespaces are now fully nvim-free. WSL / linux / mac are unchanged (still install nvim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)