### PR TITLE
feat(install): Phase 0 bootstrap + Phase 1 prep (interactive split)

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# bootstrap.sh — Phase 0 of the install workflow.
+#
+# Gets a bare machine to the point where prep (Phase 1) can run: ensures
+# git + zsh exist, clones the (public) dotfiles over https WITHOUT submodules
+# (private submodules need auth, which prep establishes), then hands off.
+#
+# Run on a fresh machine:
+#   curl -fsSL https://raw.githubusercontent.com/eduuh/dotfiles/main/bootstrap.sh | bash
+#
+# Optional: pass a profile through to prep, e.g.
+#   curl -fsSL .../bootstrap.sh | bash -s -- --profile core
+set -euo pipefail
+
+DOTFILES_REPO="${DOTFILES_REPO:-https://github.com/eduuh/dotfiles.git}"
+DOTFILES_DIR="${DOTFILES_DIR:-$HOME/projects/dotfiles}"
+
+log() { printf '\033[1;36m[bootstrap]\033[0m %s\n' "$*"; }
+err() { printf '\033[1;31m[bootstrap]\033[0m %s\n' "$*" >&2; }
+
+# Resolve the package manager just well enough to install git/zsh/curl.
+detect_pm() {
+  if command -v apt-get >/dev/null 2>&1; then echo apt
+  elif command -v pacman  >/dev/null 2>&1; then echo pacman
+  elif command -v brew    >/dev/null 2>&1; then echo brew
+  elif [ "$(uname)" = "Darwin" ]; then echo mac
+  else echo unknown
+  fi
+}
+
+# ensure_pkg <command> <package> — install only if the command is missing.
+ensure_pkg() {
+  command -v "$1" >/dev/null 2>&1 && return 0
+  log "installing $2…"
+  case "$(detect_pm)" in
+    apt)    sudo apt-get update -y && sudo apt-get install -y "$2" ;;
+    pacman) sudo pacman -S --noconfirm "$2" ;;
+    brew)   brew install "$2" ;;
+    mac)    err "Xcode Command Line Tools needed for '$1'. Run: xcode-select --install"; exit 1 ;;
+    *)      err "No supported package manager found to install '$2'."; exit 1 ;;
+  esac
+}
+
+main() {
+  log "Phase 0 — bootstrap"
+
+  ensure_pkg curl curl
+  ensure_pkg git  git
+  ensure_pkg zsh  zsh
+
+  if [ -d "$DOTFILES_DIR/.git" ]; then
+    log "dotfiles already present at $DOTFILES_DIR — skipping clone"
+  else
+    log "cloning dotfiles → $DOTFILES_DIR (https, no submodules)"
+    mkdir -p "$(dirname "$DOTFILES_DIR")"
+    git clone "$DOTFILES_REPO" "$DOTFILES_DIR"
+  fi
+
+  log "handing off to prep (Phase 1)…"
+  # Restore a real TTY for prep's interactive prompts (curl | bash leaves stdin
+  # on the pipe). Fall back to a plain exec where there's no controlling tty.
+  if [ -e /dev/tty ]; then
+    exec zsh "$DOTFILES_DIR/prep.sh" "$@" < /dev/tty
+  else
+    exec zsh "$DOTFILES_DIR/prep.sh" "$@"
+  fi
+}
+
+main "$@"

--- a/prep.sh
+++ b/prep.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env zsh
+# prep.sh — Phase 1 of the install workflow: the short, ATTENDED phase.
+#
+# Everything that needs a human lives here — sudo, GitHub sign-in + SSH key,
+# profile selection — so the long install (Phase 2) can run fully unattended.
+# After prep writes its "ready" marker, you can walk away from setup.sh.
+#
+#   ./prep.sh [--profile core|dev|desktop]
+#
+# Not `set -e`: this phase collects failures (like setup.sh) rather than aborting.
+set -uo pipefail
+
+SCRIPT_DIR="${0:A:h}"
+source "$SCRIPT_DIR/.bin/setup/common.sh"
+
+STATE_DIR="$HOME/.local/state/dotfiles"
+READY_MARKER="$STATE_DIR/ready"
+
+# Refine detect_distro() into the four install targets + termux.
+detect_target() {
+  case "$(detect_distro)" in
+    codespace) echo codespace ;;
+    darwin)    echo mac ;;
+    termux)    echo termux ;;
+    *)         if _is_wsl; then echo wsl; else echo linux; fi ;;
+  esac
+}
+
+# Default profile per target (overridable with --profile / $PROFILE).
+default_profile() {
+  case "$1" in
+    codespace|wsl) echo dev ;;
+    linux|mac)     echo desktop ;;
+    termux)        echo core ;;
+    *)             echo dev ;;
+  esac
+}
+
+main() {
+  local target profile="" arg_profile=""
+
+  # --- parse args ---
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --profile)   arg_profile="$2"; shift 2 ;;
+      --profile=*) arg_profile="${1#*=}"; shift ;;
+      *)           shift ;;
+    esac
+  done
+
+  target=$(detect_target)
+  profile="${arg_profile:-${PROFILE:-$(default_profile "$target")}}"
+
+  echo "────────────────────────────────────────"
+  echo " Phase 1 · prep   target=$target  profile=$profile"
+  echo "────────────────────────────────────────"
+
+  # 1. Cache sudo credentials so Phase 2 never prompts. Skip on codespace / root.
+  if [[ "$target" != "codespace" && "${EUID:-$(id -u)}" != "0" ]]; then
+    echo "→ Caching sudo credentials (you may be prompted once)…"
+    sudo -v || track_failure "sudo" "Failed to acquire sudo credentials"
+  fi
+
+  # 2. GitHub auth + SSH key — the part that needs you. Codespaces are pre-authed.
+  if [[ "$target" == "codespace" ]]; then
+    echo "→ Codespace detected — GitHub auth already provided, skipping gh-keys."
+  elif [[ -x "$SCRIPT_DIR/.bin/gh-keys" ]]; then
+    echo "→ Setting up GitHub CLI + SSH keys…"
+    "$SCRIPT_DIR/.bin/gh-keys" || track_failure "github" "gh-keys failed"
+  else
+    track_failure "github" "gh-keys not found at $SCRIPT_DIR/.bin/gh-keys"
+  fi
+
+  # 3. Record the resolved target + profile for the unattended install to read.
+  mkdir -p "$STATE_DIR"
+  {
+    echo "TARGET=$target"
+    echo "PROFILE=$profile"
+  } > "$READY_MARKER"
+  echo "→ Wrote $READY_MARKER"
+
+  print_failure_summary
+
+  echo ""
+  echo "Prep complete. The interactive part is done — the rest is unattended:"
+  echo ""
+  echo "    cd $SCRIPT_DIR && ./setup.sh"
+  echo ""
+  echo "(Once setup.sh becomes the Phase 2 runner it will read $READY_MARKER"
+  echo " for target+profile and skip these prompts. For now run it as-is.)"
+}
+
+main "$@"


### PR DESCRIPTION
Slice 1 of the install redesign (design: branch-notes `install-redesign.md`). Separates the interactive setup from the long unattended install so the latter never blocks on a human.

## New files (additive — `setup.sh` untouched)
- **`bootstrap.sh`** (Phase 0, `curl|bash`): ensure git+zsh, clone dotfiles over https **without submodules** (private submodules need the auth prep establishes), hand off to prep with a restored TTY for prompts.
- **`prep.sh`** (Phase 1, attended): detect target (codespace/wsl/linux/mac), resolve profile (`--profile`/`$PROFILE`/default-per-target), cache sudo, run `gh-keys`, write `~/.local/state/dotfiles/ready`. Codespaces skip sudo+gh-keys (pre-authed).

## Verified
- `bash -n` / `zsh -n` clean
- target detection on WSL → `wsl`/`dev`; codespace path → skips sudo+gh-keys, writes `TARGET/PROFILE` marker
- `--profile` override works; integrates with `common.sh` failure tracking

## Next slice
Wire `setup.sh` to read the `ready` marker and drop its own interactive bits (gh-keys/sudo/chsh), making it the unattended Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)