### PR TITLE
feat(install): make setup.sh the unattended Phase 2

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -4,18 +4,38 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 echo "Script directory: $SCRIPT_DIR"
 source "$SCRIPT_DIR/.bin/setup/common.sh"
 
-# Ask for sudo upfront and keep the session alive
-sudo -v
-while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &
-SUDO_PID=$!
+# --- Phase 2: the unattended install. Phase 1 (prep) must have run first. ---
+READY_MARKER="$HOME/.local/state/dotfiles/ready"
+if [[ ! -f "$READY_MARKER" ]]; then
+    echo "No prep marker at $READY_MARKER — the interactive Phase 1 hasn't run."
+    echo "Run it first:   ./prep.sh"
+    echo "(fresh machine: curl -fsSL https://raw.githubusercontent.com/eduuh/dotfiles/main/bootstrap.sh | bash)"
+    exit 1
+fi
+source "$READY_MARKER"   # sets TARGET, PROFILE
+echo "Phase 2 · install   target=${TARGET:-?}  profile=${PROFILE:-?}"
+
+# prep cached sudo; keep it alive WITHOUT prompting. Bail if it has lapsed so the
+# long install never blocks on a password. Skipped on codespace / root.
+SUDO_PID=""
+if [[ "$TARGET" != "codespace" && "${EUID:-$(id -u)}" != "0" ]]; then
+    if ! sudo -n true 2>/dev/null; then
+        echo "sudo credentials not cached — re-run ./prep.sh, then ./setup.sh."
+        exit 1
+    fi
+    while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &
+    SUDO_PID=$!
+fi
 
 main() {
     local distro=$(detect_distro)
 
-    # Run GitHub SSH setup script first to ensure we can clone repositories
-    echo "Setting up GitHub CLI and SSH keys..."
-    if ! "$SCRIPT_DIR/.bin/gh-keys"; then
-        track_failure "github" "Failed to setup GitHub CLI/SSH keys"
+    # GitHub auth + SSH keys are handled in prep (Phase 1), so cloning works here.
+    # Bootstrap cloned dotfiles WITHOUT submodules (private, pre-auth); now that
+    # prep established auth, populate them (bn, tmux-workflow).
+    echo "Updating dotfiles submodules..."
+    if ! git -C "$SCRIPT_DIR" submodule update --init --recursive; then
+        track_failure "submodules" "Failed to init/update dotfiles submodules"
     fi
 
     # For macOS, install Homebrew and all packages via Brewfile
@@ -70,7 +90,7 @@ main() {
     echo "To install Rust:         ./setup-rust.sh"
 
     # Clean up sudo keepalive
-    kill "$SUDO_PID" 2>/dev/null
+    [[ -n "$SUDO_PID" ]] && kill "$SUDO_PID" 2>/dev/null
 
     # Print summary of any failures
     print_failure_summary


### PR DESCRIPTION
Completes the interactive/unattended split. `setup.sh` becomes the non-blocking Phase 2 that consumes prep's marker.

## Changes
- **Require the prep marker** (`~/.local/state/dotfiles/ready`); exit with guidance (`./prep.sh` / bootstrap) if Phase 1 hasn't run.
- Read `TARGET`/`PROFILE` from the marker.
- **Drop in-line `gh-keys`** — prep owns GitHub auth + SSH keys.
- **No more prompting `sudo -v`** — non-prompting cached-sudo check + keepalive; bail if creds lapsed; skipped on codespace/root.
- **Init submodules here, after auth** — bootstrap clones dotfiles without submodules (bn/tmux-workflow are private); this is the SSH-ordering fix landing.

## Verified
- `zsh -n` clean
- No-marker run exits 1 with guidance (doesn't touch the system)
- Scanned Phase-2 paths: all `apt-get`/`rustup` use `-y`, no `read` prompts → unattended

## Behavior change
`./setup.sh` now requires `./prep.sh` to have run first (once). Known remaining mac-specific interactive step: Homebrew install (`NONINTERACTIVE=1` / move to prep) — follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)