### PR TITLE
feat(install): profile + target filtering for steps

### DIFF
--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -61,6 +61,46 @@ reset_steps() {
     echo "Cleared step state ($SETUP_DONE_FILE)."
 }
 
+# --- Profiles & targets ----------------------------------------------------
+# Nested tiers: core ⊂ dev ⊂ desktop. The active PROFILE includes its own tier
+# and every tier below it. TARGET is one of codespace|wsl|linux|mac|termux.
+# Both come from the prep "ready" marker.
+_profile_rank() {
+    case "$1" in core) echo 1;; dev) echo 2;; desktop) echo 3;; *) echo 0;; esac
+}
+
+# True if the active PROFILE includes tier $1.
+_profile_includes() {
+    [[ $(_profile_rank "${PROFILE:-desktop}") -ge $(_profile_rank "$1") ]]
+}
+
+# True if the active TARGET is in $1 ("all" or a comma list like "linux,mac").
+_target_matches() {
+    [[ "$1" == "all" ]] && return 0
+    local t
+    for t in ${(s:,:)1}; do
+        [[ "$t" == "${TARGET:-}" ]] && return 0
+    done
+    return 1
+}
+
+# step <name> <min_profile> <targets> <command> [args...]
+#   min_profile: core|dev|desktop — run only if the active PROFILE includes it
+#   targets:     "all" or csv (e.g. "linux,mac") — run only if TARGET matches
+# Passes through to run_step (so it's still idempotent + resumable).
+step() {
+    local name="$1" min_profile="$2" targets="$3"; shift 3
+    if ! _profile_includes "$min_profile"; then
+        echo "· [$name] skipped (profile ${PROFILE:-?} < $min_profile)"
+        return 0
+    fi
+    if ! _target_matches "$targets"; then
+        echo "· [$name] skipped (target ${TARGET:-?} not in $targets)"
+        return 0
+    fi
+    run_step "$name" "$@"
+}
+
 # Install a package with error tracking (generic wrapper)
 install_package() {
     local pkg="$1"

--- a/setup.sh
+++ b/setup.sh
@@ -4,11 +4,18 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 echo "Script directory: $SCRIPT_DIR"
 source "$SCRIPT_DIR/.bin/setup/common.sh"
 
-# --- flags: `--force` re-runs every step; `reset` clears recorded step state ---
-for arg in "$@"; do
-    case "$arg" in
-        --force) SETUP_FORCE=true ;;
-        reset)   reset_steps; exit 0 ;;
+# --- flags ---
+#   --force          re-run every step
+#   --profile <tier> override the profile from the prep marker (core|dev|desktop)
+#   reset            clear recorded step state and exit
+SETUP_PROFILE_OVERRIDE=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --force)     SETUP_FORCE=true; shift ;;
+        --profile)   SETUP_PROFILE_OVERRIDE="$2"; shift 2 ;;
+        --profile=*) SETUP_PROFILE_OVERRIDE="${1#*=}"; shift ;;
+        reset)       reset_steps; exit 0 ;;
+        *)           shift ;;
     esac
 done
 
@@ -21,6 +28,7 @@ if [[ ! -f "$READY_MARKER" ]]; then
     exit 1
 fi
 source "$READY_MARKER"   # sets TARGET, PROFILE
+PROFILE="${SETUP_PROFILE_OVERRIDE:-$PROFILE}"   # --profile wins over the marker
 echo "Phase 2 · install   target=${TARGET:-?}  profile=${PROFILE:-?}"
 
 # prep cached sudo; keep it alive WITHOUT prompting. Bail if it has lapsed so the
@@ -68,18 +76,19 @@ main() {
         *) track_failure "distro" "Unsupported distribution: $distro"; print_failure_summary; exit 1 ;;
     esac
 
-    # Each step records on success → re-runs skip it, a failed run resumes here.
-    run_step submodules         _init_submodules
-    run_step "platform-$distro" run_platform_setup "$distro"
+    # step <name> <min-profile> <targets> <cmd…> — profile/target filtered,
+    # then idempotent + resumable. Records on success; failed steps resume.
+    step submodules         core all   _init_submodules
+    step "platform-$distro" core all   run_platform_setup "$distro"
 
     if [ "$distro" != "termux" ]; then
-        run_step tmux-plugins install_tmux_plugins
-        run_step zoxide       install_zoxide
-        run_step starship     install_starship
-        run_step pnpm         install_pnpm
-        run_step talosctl     install_talosctl
-        run_step git-hooks    setup_git_hooks
-        run_step shell-zsh    change_shell_to_zsh
+        step tmux-plugins core all   install_tmux_plugins
+        step zoxide       core all   install_zoxide
+        step starship     core all   install_starship
+        step pnpm         dev  all   install_pnpm
+        step talosctl     dev  all   install_talosctl
+        step git-hooks    core all   setup_git_hooks
+        step shell-zsh    core all   change_shell_to_zsh
     fi
 
     echo ""


### PR DESCRIPTION
Slice 4 of the install redesign — the **core ⊂ dev ⊂ desktop** profile model layered onto the step runner.

## What
- **`step <name> <min-profile> <targets> <cmd…>`** — runs only if the active `PROFILE` includes the step's tier AND `TARGET` matches, then passes through to `run_step` (still idempotent + resumable).
- Helpers `_profile_includes` (nested ranks: core<dev<desktop) and `_target_matches` ("all" or csv like `linux,mac`).
- `setup.sh` tags each step: `pnpm`/`talosctl` = **dev**, the rest = **core**. Adds `--profile <tier>` to override the prep marker.

`PROFILE`/`TARGET` come from the prep `ready` marker; `--profile` overrides.

## Effect
- `--profile core` → minimal install (skips pnpm/talosctl and any dev/desktop step)
- `dev` (codespace/wsl default) → + dev tooling
- `desktop` (linux/mac default) → + desktop/hardware steps, target-gated

## Verified (isolated)
| PROFILE | TARGET | core | dev | desktop | kanata(linux,mac) |
|---------|--------|------|-----|---------|-------------------|
| core | wsl | ✓ | skip | skip | skip |
| dev | wsl | ✓ | ✓ | skip | skip |
| desktop | linux | ✓ | ✓ | ✓ | ✓ |
| desktop | mac | ✓ | ✓ | ✓ | ✓ |

`zsh -n` clean on both files.

## Follow-up
Desktop-tier items (kanata, services) still live inside the platform scripts; hoisting them into top-level `desktop` steps is a later refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)