### PR TITLE
feat(install): consolidate cloner with the wt worktree system

### DIFF
--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -169,8 +169,13 @@ detect_distro() {
     fi
 }
 
-# Repos that get regular (non-bare) clones at ~/projects/reponame
-REGULAR_CLONE_REPOS=(dotfiles nvim personal-notes eduuh notes bn tmux-workflow)
+# Repos that get regular (non-bare) clones at ~/projects/reponame.
+# Single source of truth, shared with .bin/wt (see regular-repos.zsh).
+if [[ -f "$_COMMON_DIR/regular-repos.zsh" ]]; then
+    source "$_COMMON_DIR/regular-repos.zsh"
+else
+    REGULAR_CLONE_REPOS=(dotfiles nvim personal-notes eduuh notes bn tmux-workflow)
+fi
 
 # Repos that should live on the Windows filesystem when on WSL
 # (cloned to $WINDOWS_PROJECTS_DIR/<name>, symlinked at ~/projects/<name>)
@@ -285,17 +290,11 @@ _clone_single_repo() {
             fi
             cd ~
         else
-            echo "[$REPO_NAME] Cloning (bare)..."
-            git clone --bare "$REPO" "$BARE_PATH" || { echo "[$REPO_NAME] Failed to clone."; return 1; }
-
-            cd "$BARE_PATH" || return 1
-            git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-            git fetch origin
-            local DEFAULT_BRANCH=$(git symbolic-ref --short HEAD)
-
-            mkdir -p "$WT_BASE"
-            git worktree add "$WT_BASE/$DEFAULT_BRANCH" "$DEFAULT_BRANCH"
-            cd ~
+            # Fresh bare clone — delegate to the worktree manager so there's one
+            # implementation of "bare clone + default-branch worktree". wt uses
+            # the same regular-repos.zsh classification, so it agrees this is bare.
+            echo "[$REPO_NAME] Cloning (bare) via wt..."
+            "$_COMMON_DIR/../wt" clone "$REPO" || track_failure "$REPO_NAME" "wt clone failed for $REPO"
         fi
     fi
 }

--- a/.bin/setup/regular-repos.zsh
+++ b/.bin/setup/regular-repos.zsh
@@ -1,0 +1,19 @@
+# regular-repos.zsh — single source of truth for which repos are cloned FLAT
+# (regular ~/projects/<name>) instead of bare + worktree.
+#
+# Sourced by both the install bootstrap (.bin/setup/common.sh) and the worktree
+# manager (.bin/wt) so the two never disagree. Everything NOT listed here is
+# cloned bare with a default-branch worktree under ~/projects/{bare,worktree}.
+#
+# Rule of thumb: tools/config you don't branch-develop are flat; project repos
+# where you do feature-branch work are bare+worktree.
+
+REGULAR_CLONE_REPOS=(
+    dotfiles
+    nvim
+    personal-notes
+    eduuh
+    notes
+    bn
+    tmux-workflow
+)

--- a/.bin/wt
+++ b/.bin/wt
@@ -5,12 +5,14 @@
 
 set -e
 
-# Repositories that should NOT be cloned as bare (regular clone instead)
-# These repos will be cloned to ~/projects/reponame (without .git suffix)
-REGULAR_CLONE_REPOS=(
-    "dotfiles"
-    "nvim"
-)
+# Repositories that should NOT be cloned as bare (regular clone instead).
+# Single source of truth, shared with the install bootstrap (see
+# .bin/setup/regular-repos.zsh). Everything else clones bare + worktree.
+if [[ -f "${0:A:h}/setup/regular-repos.zsh" ]]; then
+    source "${0:A:h}/setup/regular-repos.zsh"
+else
+    REGULAR_CLONE_REPOS=(dotfiles nvim)
+fi
 
 usage() {
     cat << EOF


### PR DESCRIPTION
Final slice of the install redesign — make the bootstrap cloner *use* the worktree system instead of shadowing it.

## Problem
The bootstrap (`common.sh`) and `wt` each kept their own flat-vs-bare `REGULAR_CLONE_REPOS` list — **and they disagreed** (common.sh: 7 repos; wt: just `dotfiles nvim`). So `wt clone bn` would have made `bn` *bare* while the bootstrap makes it *flat*. They also each re-implemented bare clone + worktree add.

## Fix
- **`regular-repos.zsh`** — single source of truth for the flat-clone list, sourced by both `common.sh` and `wt` (each with a fallback). Drift is now impossible.
- **`common.sh` delegates** the fresh bare-clone to `wt clone` (one implementation of bare + default-branch worktree). The *update-existing* path stays in common.sh, since `wt clone` errors on an existing repo. Both use the shared list → consistent.

Cloning utilities stay in dotfiles (per the earlier boundary decision).

## Verified
- `zsh -n` clean on all three files
- Shared list loads **identically** in the shared file, common.sh, and wt's context (7 repos) — `wt clone bn` now correctly flat
- `wt list` runs; delegation path resolves to the wt executable

🤖 Generated with [Claude Code](https://claude.com/claude-code)