### PR TITLE
fix(bn): resolve bn on a fresh machine via a dispatcher shim

### DIFF
--- a/.bin/bn
+++ b/.bin/bn
@@ -1,1 +1,9 @@
-/home/edd/projects/bn/target/release/bn
+#!/usr/bin/env sh
+# bn dispatcher. Prefer the compiled Rust binary; fall back to the bash bn.
+# The Rust binary is built from the bn-repo submodule by setup (cargo build).
+# Where Rust isn't built (e.g. Codespaces, which skip the toolchain) the bash
+# bn takes over, so `bn` always resolves to a working implementation.
+d=$(dirname "$0")
+rs="$d/bn-repo/target/release/bn"
+[ -x "$rs" ] && exec "$rs" "$@"
+exec "$d/bn-bash" "$@"

--- a/.bin/bn-rs
+++ b/.bin/bn-rs
@@ -1,1 +1,1 @@
-/home/edd/projects/bn/target/release/bn
+bn-repo/target/release/bn

--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -674,6 +674,26 @@ install_rust() {
     fi
 }
 
+build_bn() {
+    # Compile the Rust bn from the bn-repo submodule. The committed .bin/bn shim
+    # prefers this binary and falls back to the bash bn when it's absent, so a
+    # failed/skipped build degrades gracefully rather than breaking bn.
+    if [[ $CODESPACES == "true" ]]; then
+        echo "Codespace: skipping Rust bn build (bn falls back to the bash implementation)."
+        return 0
+    fi
+
+    if ! command -v cargo &> /dev/null; then
+        install_rust
+        command -v cargo &> /dev/null || { echo "cargo unavailable; bn uses the bash fallback."; return 0; }
+    fi
+
+    echo "Building Rust bn…"
+    if ! cargo build --release --manifest-path "$_COMMON_DIR/../bn-repo/Cargo.toml" -p bn-cli; then
+        track_failure "bn" "Failed to build Rust bn"
+    fi
+}
+
 install_playwright() {
     if command -v playwright &> /dev/null; then
         echo "Playwright is already installed."

--- a/setup.sh
+++ b/setup.sh
@@ -79,6 +79,7 @@ main() {
     # step <name> <min-profile> <targets> <cmd…> — profile/target filtered,
     # then idempotent + resumable. Records on success; failed steps resume.
     step submodules         core all   _init_submodules
+    step bn                 core all   build_bn
     step "platform-$distro" core all   run_platform_setup "$distro"
 
     if [ "$distro" != "termux" ]; then


### PR DESCRIPTION
## Problem
`.bin/bn` was an **absolute** symlink to `/home/edd/projects/bn/target/release/bn`, which doesn't exist on a fresh clone — so `bn` (including the `bn --cat` SessionStart hook) would break on any new machine. The `bn-repo` submodule was also pinned to a bash-only commit with no Rust source, and no setup step built the binary.

## Fix
- **`.bin/bn`** → dispatcher shim: execs the compiled Rust binary if built, else falls back to `bn-bash`. Never dangles — works on every target, including Codespaces (which skip the Rust toolchain).
- **`.bin/bn-rs`** → relative `bn-repo/target/release/bn` (was absolute).
- **`.bin/bn-repo`** submodule bumped `d28d9a2` → `b16dfda` (now carries the Rust source + crates).
- **`setup.sh`** → new `core` step `bn` builds the binary from the submodule via `build_bn` (installs Rust if missing, skips Codespaces, degrades to the bash fallback on failure).

## Verification
- Built from the submodule (`cargo build --release -p bn-cli`) — shim resolves to the Rust binary; `bn status` / `--help` work.
- Hid the binary → shim correctly falls back to `bn-bash`.
- No lingering references to the old absolute path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)