### PR TITLE
refactor(tmux): consolidate tmux-workflow into the bn submodule

### DIFF
--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -174,7 +174,7 @@ detect_distro() {
 if [[ -f "$_COMMON_DIR/regular-repos.zsh" ]]; then
     source "$_COMMON_DIR/regular-repos.zsh"
 else
-    REGULAR_CLONE_REPOS=(dotfiles nvim personal-notes eduuh notes bn tmux-workflow)
+    REGULAR_CLONE_REPOS=(dotfiles nvim personal-notes eduuh notes bn)
 fi
 
 # Repos that should live on the Windows filesystem when on WSL
@@ -375,7 +375,6 @@ clone_repos() {
             "git@github.com:eduuh-private/personal-notes.git"
             "git@github.com:eduuh/eduuh.git"
             "git@github.com:eduuh/bn.git"
-            "git@github.com:eduuh/tmux-workflow.git"
         )
 
         if [ "$is_wsl" = true ] && [ "$(hostname)" = "edwin" ]; then

--- a/.bin/setup/regular-repos.zsh
+++ b/.bin/setup/regular-repos.zsh
@@ -15,5 +15,4 @@ REGULAR_CLONE_REPOS=(
     eduuh
     notes
     bn
-    tmux-workflow
 )

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule ".bin/bn-repo"]
 	path = .bin/bn-repo
 	url = git@github.com:eduuh/bn.git
-[submodule ".bin/tmux-workflow"]
-	path = .bin/tmux-workflow
-	url = git@github.com:eduuh/tmux-workflow.git

--- a/setup.sh
+++ b/setup.sh
@@ -43,7 +43,7 @@ if [[ "$TARGET" != "codespace" && "${EUID:-$(id -u)}" != "0" ]]; then
     SUDO_PID=$!
 fi
 
-# Populate dotfiles submodules (bn, tmux-workflow). Bootstrap skipped them
+# Populate dotfiles submodules (bn; tmux-workflow lives inside it). Bootstrap skipped them
 # pre-auth; prep has since established GitHub auth.
 _init_submodules() {
     git -C "$SCRIPT_DIR" submodule update --init --recursive


### PR DESCRIPTION
## Why
`eduuh/tmux-workflow` is now **archived** — its entire content (helpers, lib, and `tmux.conf`) was absorbed into `eduuh/bn` at `bn-repo/workflow/`. Dotfiles still wired it as a separate submodule, leaving two copies of the same code.

## What
Retire the standalone `.bin/tmux-workflow` submodule and point everything at the copy inside the `bn` submodule — single source of truth for the tmux layer.

- **`.bin/tmux-workflow`**: submodule → symlink into `bn-repo/workflow`.
  `tmux.conf` hardcodes `$HOME/.bin/tmux-workflow/bin/...` for its helpers, so the symlink preserves that path contract with **zero edits to the upstream config**.
- **`.gitmodules`**: drop the `tmux-workflow` submodule (only `bn-repo` remains).
- **`regular-repos.zsh` + `common.sh`**: drop `tmux-workflow` from the clone lists (it ships inside bn now).
- **`setup.sh`**: update the submodule comment.

## Verification
- `.tmux.conf` → `.bin/tmux-workflow/tmux.conf` → `bn-repo/workflow/tmux.conf` resolves.
- `~/.bin/tmux-workflow/bin/tat` → `bn-repo/workflow/bin/tat` resolves (all hardcoded helper paths work).
- `tmux -f .tmux.conf new-session` parses the live config successfully.
- No remaining dotfiles-owned references to a standalone tmux-workflow clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)