### PR TITLE
fix(setup): default optional env vars so common.sh survives set -u

### DIFF
--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -5,6 +5,13 @@
 _COMMON_DIR="${${(%):-%x}:A:h}"
 [[ -f "$_COMMON_DIR/../../versions.lock" ]] && source "$_COMMON_DIR/../../versions.lock"
 
+# Optional external env vars, defaulted so common.sh is safe under `set -u`. prep.sh sources
+# this with `set -u`; an unset reference there aborts the whole source, which would drop
+# every function defined below the first such reference (e.g. detect_distro / _is_wsl).
+: "${CODESPACES:=}"
+: "${TERMUX_VERSION:=}"
+: "${WINDOWS_PROJECTS_DIR:=}"
+
 # Failure tracking - collect errors instead of exiting
 typeset -ga SETUP_FAILURES=()
 


### PR DESCRIPTION
## Problem

Running `prep.sh` on a non-Codespaces machine failed:

```
common.sh:147: CODESPACES: parameter not set
detect_target:1: command not found: detect_distro
detect_target:5: command not found: _is_wsl
```

`prep.sh` sources `common.sh` under `set -u`. `$CODESPACES` is unset off Codespaces, so `[ "$CODESPACES" = "true" ]` near the top of `common.sh` aborted the **entire source** — which meant every function defined *below* that line (`detect_distro`, `_is_wsl`, …) was never created. `prep.sh`'s `detect_target` then couldn't find them.

## Fix

Default the optional external env vars (`CODESPACES`, `TERMUX_VERSION`, `WINDOWS_PROJECTS_DIR`) once near the top of `common.sh`, so every later reference is safe under `set -u`. Behaviour is identical when the vars are set.

## Verification

```
$ zsh -c 'set -uo pipefail; source .bin/setup/common.sh && detect_distro'
ubuntu          # was: aborted at line 147
# full prep detect path now returns target=wsl
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)