### PR TITLE
feat(setup): clone projects + install Rust automatically in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -79,6 +79,7 @@ main() {
     # step <name> <min-profile> <targets> <cmd…> — profile/target filtered,
     # then idempotent + resumable. Records on success; failed steps resume.
     step submodules         core all   _init_submodules
+    step rust               core wsl,linux,mac,termux install_rust
     step bn                 core all   build_bn
     step "platform-$distro" core all   run_platform_setup "$distro"
 
@@ -92,9 +93,10 @@ main() {
         step shell-zsh    core all   change_shell_to_zsh
     fi
 
-    echo ""
-    echo "To clone project repos:  ./setup-projects.sh"
-    echo "To install Rust:         ./setup-rust.sh"
+    # Project repos: prep already established GitHub auth, so cloning is safe here.
+    # Idempotent — existing clones are skipped. (setup-projects.sh still works standalone.)
+    step projects   core all   clone_repos
+    step notes-stow core all   setup_personal_notes_stow
 
     # Clean up sudo keepalive
     [[ -n "$SUDO_PID" ]] && kill "$SUDO_PID" 2>/dev/null


### PR DESCRIPTION
Promotes the two previously-manual steps (`./setup-projects.sh`, `./setup-rust.sh`) into automatic, resumable `setup.sh` steps so one `./setup.sh` provisions a machine end to end.

- **Rust** — `step rust core wsl,linux,mac,termux install_rust`, placed before the `bn` build so `build_bn` always finds cargo. Skipped on codespace (verified per target).
- **Projects** — `step projects` + `step notes-stow` always clone the project repos and stow personal notes. `setup.sh` already requires the prep "ready" marker, so GitHub auth is established before cloning runs. Both are idempotent (existing clones skipped).

`setup-projects.sh` / `setup-rust.sh` remain for standalone re-runs.

Verified: `zsh -n setup.sh` clean; target gating runs on wsl/linux/mac/termux and skips codespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)