### PR TITLE
feat(wt): WSL-driven worktrees on the Windows filesystem (wtw)

### DIFF
--- a/.bin/wt
+++ b/.bin/wt
@@ -14,6 +14,20 @@ else
     REGULAR_CLONE_REPOS=(dotfiles nvim)
 fi
 
+# Project layout. Defaults to ~/projects (fast ext4). $WT_ROOT lets a wrapper
+# (e.g. wtw) point this same worktree logic at a different root — such as the
+# Windows filesystem — without duplicating any of the logic below.
+PROJECT_ROOT="${WT_ROOT:-$HOME/projects}"
+BARE_DIR="$PROJECT_ROOT/bare"
+WORKTREE_DIR="$PROJECT_ROOT/worktree"
+
+# Colors (previously inherited from the retired tmux-lib.sh)
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
 usage() {
     cat << EOF
 Usage: wt <command> [args]

--- a/.bin/wtw
+++ b/.bin/wtw
@@ -1,0 +1,32 @@
+#!/usr/bin/env zsh
+# wtw - wt, but rooted on the Windows filesystem.
+#
+# Same bare+worktree workflow as `wt`, pointed at a Windows "code" directory so
+# Windows-native tools can read/build the files while WSL stays the SOLE git
+# driver. Everything is delegated to `wt`; this only resolves the root.
+#
+# The root is machine-local on purpose: the public dotfiles must not carry a
+# corporate username/path (mirrors the ~/.config/bn/ convention).
+set -e
+
+config="${XDG_CONFIG_HOME:-$HOME/.config}/wt/win-root"
+
+if [[ -f "$config" ]]; then
+    WT_ROOT="$(<"$config")"
+elif command -v wslpath >/dev/null 2>&1; then
+    # Fallback: derive <WindowsHome>/code from %USERPROFILE%.
+    win_home="$(cmd.exe /c 'echo %USERPROFILE%' 2>/dev/null | tr -d '\r')"
+    [[ -n "$win_home" ]] && WT_ROOT="$(wslpath "$win_home")/code"
+fi
+
+WT_ROOT="${WT_ROOT%/}"   # strip trailing slash / newline
+
+if [[ -z "$WT_ROOT" ]]; then
+    echo "wtw: no Windows repos root configured." >&2
+    echo "     Write the WSL path (e.g. /mnt/c/Users/<you>/code) to:" >&2
+    echo "     $config" >&2
+    exit 1
+fi
+
+export WT_ROOT
+exec "${0:A:h}/wt" "$@"

--- a/.zshrc
+++ b/.zshrc
@@ -75,6 +75,17 @@ wt() {
     fi
 }
 
+# Same wrapper for repos that live on the Windows filesystem (wtw go must cd too)
+wtw() {
+    if [[ "$1" == "go" ]]; then
+        local dir
+        dir=$("$HOME/.bin/wtw" go "${@:2}")
+        [[ -n "$dir" && -d "$dir" ]] && cd "$dir"
+    else
+        "$HOME/.bin/wtw" "$@"
+    fi
+}
+
 # Branch note quick-add
 t() { "$HOME/.bin/bn" add todo "$*" }
 unalias r 2>/dev/null  # override zsh's default r=fc (repeat last command)


### PR DESCRIPTION
## Why

Make **WSL the single entry point** for managing repos that must live on the Windows filesystem (so Windows-native tools can read/build them at native paths), instead of driving them from a slow Windows-side terminal.

## What

- **`wtw`** — `wt`, but rooted on Windows. Same workflow (`clone`/`add`/`list`/`go`/`cleanup`), pointed at a Windows `code/` dir. WSL stays the **sole git driver**; Windows tools only read/build the files.
- **One seam, zero duplication:** `wt` now resolves `PROJECT_ROOT="${WT_ROOT:-$HOME/projects}"`. `wtw` is a thin wrapper that sets `WT_ROOT` and `exec`s `wt`.
- **Privacy:** the Windows root is read from machine-local `~/.config/wt/win-root` (mirrors the `~/.config/bn/` convention), falling back to `<%USERPROFILE%>/code`. The public dotfiles carry no corporate path.
- Adds a `wtw()` shell function mirroring `wt()` so `wtw go` can `cd`.

## Drive-by fix

`wt` had been **silently broken** since `b4549cf`: that commit dropped `source ~/.bin/tmux/tmux-lib.sh`, which was what defined `PROJECT_ROOT`/`BARE_DIR`/`WORKTREE_DIR` and the color vars — so `wt list` returned nothing. Restored inline (first commit), which is also the seam this feature builds on.

## Validation

End-to-end on `/mnt/c` (v9fs): `clone` (bare+worktree), `add -b`, `list` all work; gitdir pointers are WSL-native (correct for the sole-driver model); `git status` works inside a Windows-FS worktree. Test repo cleaned up afterward.

## Note

git on `/mnt/c` (v9fs) is slower than ext4 — migrate only repos that genuinely need Windows-native paths; leave the rest on `~/projects`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)