### PR TITLE
chore(tmux): raise version floor to 3.5 + bump bn-repo (workflow v2)

### DIFF
--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -448,7 +448,10 @@ _run_work_setup_from_personal_notes() {
 }
 
 ensure_tmux_version() {
-    local min_version="3.2"
+    # 3.5 is the floor: popup borders/titles (3.4) and robust OSC52 set-clipboard
+    # (3.3) are relied on by tmux.conf. 3.2a (Ubuntu's apt candidate) is too old,
+    # so this triggers the from-source build below.
+    local min_version="3.5"
 
     # macOS via Homebrew always has recent tmux, skip
     if [[ "$(uname)" == "Darwin" ]]; then


### PR DESCRIPTION
Two changes that pair with eduuh/bn#12 (the tmux config lives in the `.bin/bn-repo` submodule).

## `ensure_tmux_version` floor 3.2 → 3.5
The from-source tmux builder (deps + 3.5a) was already wired into `setup_ubuntu` / `setup_codespace` / arch, but never triggered: the gate accepted 3.2a (Ubuntu's apt candidate). The new tmux config relies on 3.4 popup borders/titles and 3.3 OSC52 `set-clipboard`, so 3.5 is the real floor. Running setup now builds + installs 3.5a from source.

## Submodule bump: bn-repo workflow v2
Tracks the tmux workflow overhaul (Tiers A/B/C) — see eduuh/bn#12 for detail.

**Merge order:** eduuh/bn#12 first, then re-point this submodule bump at the merge commit if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)