### PR TITLE
chore(setup): drop personal wira360 from the work-laptop clone list

### DIFF
--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -403,7 +403,6 @@ clone_repos() {
 
         if [ "$is_wsl" = true ] && [ "$(hostname)" = "edwin" ]; then
             REPOSITORIES+=(
-                "git@github.com:eduuh/wira360.git"
                 "git@github.com:eduuh/kube-homelab.git"
                 "git@github.com:eduuh/bits-and-atoms.git"
             )


### PR DESCRIPTION
wira360 is a personal repo — it shouldn't be cloned or refreshed on the work machine (it was showing up in `bn run refresh-all` as non-fast-forwardable).

- Removes `wira360.git` from the `is_wsl && hostname==edwin` REPOSITORIES block in `.bin/setup/common.sh`.
- The bare repo + both worktrees (`main`, `mcp-server`) were also removed from disk. Local-only work there was confirmed safe elsewhere before deletion.

Surgical: isolated to just the wira360 line (an unrelated in-progress `atlas.git` edit in the same file was left untouched).