### PR TITLE
feat(systemd): track bn-refresh user timer + enablement

### DIFF
--- a/.config/systemd/user/bn-refresh.service
+++ b/.config/systemd/user/bn-refresh.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=bn — refresh all branch-note worktrees (fetch, fast-forward, rebuild)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+# `bn run` records the outcome to the event log so `bn cron status` / `bn doctor` see it.
+ExecStart=%h/.bin/bn run refresh-all

--- a/.config/systemd/user/bn-refresh.timer
+++ b/.config/systemd/user/bn-refresh.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Daily bn refresh-all
+
+[Timer]
+OnCalendar=daily
+# Catch up a run missed while WSL was shut down at the scheduled time (fires on next boot).
+Persistent=true
+# Spread the wake so several machines don't all fetch at the same instant.
+RandomizedDelaySec=5m
+
+[Install]
+WantedBy=timers.target

--- a/.config/systemd/user/timers.target.wants/bn-refresh.timer
+++ b/.config/systemd/user/timers.target.wants/bn-refresh.timer
@@ -1,0 +1,1 @@
+../bn-refresh.timer


### PR DESCRIPTION
Makes the daily `bn run refresh-all` timer declarative through stow-managed `~/.config/systemd` (which is already a directory-symlink into this repo).

- Tracks `bn-refresh.service` + `bn-refresh.timer` (the deployed copy of bn's `jobs/systemd/` units).
- Tracks the `timers.target.wants/bn-refresh.timer` enablement symlink, converted from an absolute `/home/edd/...` path to a **relative** `../bn-refresh.timer` so it's portable across machines/users.

Verified: after the relative-symlink swap + `daemon-reload`, the timer is still `enabled` + `active`, next run scheduled. Follow-up to bn#22 (the units' source of truth).