### PR TITLE
feat(setup): clone atlas on setup; fix flat tat/wt-clone commands

### DIFF
--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -399,6 +399,7 @@ clone_repos() {
             "git@github.com:eduuh-private/personal-notes.git"
             "git@github.com:eduuh/eduuh.git"
             "git@github.com:eduuh/bn.git"
+            "git@github.com:eduuh/atlas.git"
         )
 
         if [ "$is_wsl" = true ] && [ "$(hostname)" = "edwin" ]; then

--- a/.bin/tat
+++ b/.bin/tat
@@ -1,0 +1,1 @@
+bn-repo/workflow/bin/tat

--- a/.bin/wt-clone
+++ b/.bin/wt-clone
@@ -1,0 +1,1 @@
+bn-repo/workflow/bin/wt-clone


### PR DESCRIPTION
## What

- **Clone `eduuh/atlas` on setup** — added to the non-codespaces clone list next to `bn`; gets the default bare+worktree layout (it's a branch-developed .NET/React project, so not a flat clone).
- **Fix flat `tat` / `wt-clone` commands** — bump `bn-repo` → `06e45a1`, which adds the `tatw`-style symlink-resolution walk so they resolve `WF_ROOT` from the real `workflow/` dir instead of next to the `~/.bin` PATH symlink. `wt-clone` also gained its exec bit (was `100644`).
- **Track the flat symlinks** — `.bin/tat` and `.bin/wt-clone` now point at the submodule (`bn-repo/workflow/bin/...`), matching `.bin/tatw`, so they're reproducible on a fresh machine instead of absolute dev-clone paths.

## Verification

- `~/.bin/tat --check` → `WF_ROOT=.../bn-repo/workflow`, fzf/tmux/zoxide ok, lists `atlas`.
- `~/.bin/wt-clone` → prints usage (no lib-not-found / permission-denied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)