### PR TITLE
fix(setup): clone personal branch-notes from its remote

### DIFF
--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -373,7 +373,7 @@ _setup_one_branch_notes_repo() {
 # $HOME/.config/bn/work-repos (allowlist, gitignored).
 setup_branch_notes_symlink() {
     _is_wsl || return 0
-    _setup_one_branch_notes_repo "branch-notes"
+    _setup_one_branch_notes_repo "branch-notes" "git@github.com:eduuh/branch-notes.git"
 }
 
 clone_repos() {


### PR DESCRIPTION
`setup_branch_notes_symlink()` called `_setup_one_branch_notes_repo "branch-notes"` with **no remote**, so a fresh machine got an empty `git init` repo instead of the note history. Now that `eduuh/branch-notes` exists as the private remote, pass it so setup clones from it.

The work-notes repo (`branch-notes-work`) is already cloned with its EMU remote via the private `personal-notes/scripts/setup-work-repos.sh`, so both branch-note repos now provision correctly on a new laptop.