### PR TITLE
chore(setup): bn-mcp install + ignore local build artifact

### DIFF
--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -709,9 +709,12 @@ install_rust() {
 }
 
 build_bn() {
-    # Compile the Rust bn from the bn-repo submodule. The committed .bin/bn shim
-    # prefers this binary and falls back to the bash bn when it's absent, so a
-    # failed/skipped build degrades gracefully rather than breaking bn.
+    # Install the Rust bn from the bn-repo submodule by delegating to its own
+    # installer. install.sh builds bn + bn-mcp, copies them to ~/.bin, and registers
+    # the bn-mcp stdio server globally for Claude Code + Copilot (idempotent — safe to
+    # re-run, --force re-runs this step). --core skips bn's tmux layer (dotfiles owns
+    # tmux); BN_BUILD_FROM_SOURCE=1 builds the pinned submodule rather than pulling a
+    # GitHub release, so the binaries match the commit this repo points at.
     if [[ $CODESPACES == "true" ]]; then
         echo "Codespace: skipping Rust bn build (bn falls back to the bash implementation)."
         return 0
@@ -722,9 +725,9 @@ build_bn() {
         command -v cargo &> /dev/null || { echo "cargo unavailable; bn uses the bash fallback."; return 0; }
     fi
 
-    echo "Building Rust bn…"
-    if ! cargo build --release --manifest-path "$_COMMON_DIR/../bn-repo/Cargo.toml" -p bn-cli; then
-        track_failure "bn" "Failed to build Rust bn"
+    echo "Installing Rust bn (+ bn-mcp, + global MCP registration)…"
+    if ! BN_BUILD_FROM_SOURCE=1 bash "$_COMMON_DIR/../bn-repo/install.sh" --core; then
+        track_failure "bn" "Failed to install Rust bn"
     fi
 }
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 .config/nvim
 .config/github-copilot/apps.json
 .config/github-copilot/versions.json
+
+# Local compiled bn artifacts. The bn binary is built into the bn-repo
+# submodule's target/ and reached via the tracked .bin/bn shim; bn-mcp is a
+# locally-built MCP server. Neither belongs in the dotfiles tree.
+.bin/bn-mcp


### PR DESCRIPTION
## What

Follow-ups from the new-laptop setup audit — the local bn build artifacts weren't accounted for.

- **Ignore `.bin/bn-mcp`** — a locally-built MCP server binary that was showing as untracked. The compiled bn binary lives in the bn-repo submodule's `target/` and is reached via the tracked `.bin/bn` shim; neither binary belongs in the tree.
- **`build_bn()` delegates to `bn-repo/install.sh --core`** (`BN_BUILD_FROM_SOURCE=1`) instead of a bare `cargo build`. The installer builds bn **and** bn-mcp, copies them to `~/.bin`, and registers the bn-mcp stdio server for Claude Code + Copilot — idempotent. `--core` skips bn's tmux layer (dotfiles owns tmux); building from source pins to the submodule commit rather than a GitHub release.

## Not included (deliberately)

- `.bin/bn` — tracked as the shim; the local compiled copy is guarded with `git update-index --skip-worktree` (gitignore is inert on tracked paths). Restored the shim in the working tree.
- `.bin/bn-bash` — reverted a stray flip to an absolute symlink path back to relative `bn-repo/bn` (portability).
- `.bin/bn-repo` dirty `Cargo.toml`/`Cargo.lock` — submodule-internal WIP, belongs in the bn repo, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)