### PR TITLE
feat(setup): --work flag installs work-machine tools from personal-notes

### DIFF
--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -464,6 +464,19 @@ _run_work_setup_from_personal_notes() {
     echo "Work repo setup finished."
 }
 
+# Work-machine tool installs (agency, etc.). Runs only via `setup.sh --work`.
+# Delegates to a script in the private personal-notes repo so internal MS
+# endpoints stay out of public dotfiles. No-op if the script is absent.
+install_work_tools() {
+    local work_tools="${WORK_TOOLS_SCRIPT:-$HOME/projects/personal-notes/scripts/setup-work-tools.sh}"
+    if [[ ! -f "$work_tools" ]]; then
+        echo "· no work-tools script at $work_tools — skipping"
+        return 0
+    fi
+    echo "Sourcing work tools script: $work_tools"
+    source "$work_tools"
+}
+
 ensure_tmux_version() {
     # 3.5 is the floor: popup borders/titles (3.4) and robust OSC52 set-clipboard
     # (3.3) are relied on by tmux.conf. 3.2a (Ubuntu's apt candidate) is too old,

--- a/setup.sh
+++ b/setup.sh
@@ -7,13 +7,16 @@ source "$SCRIPT_DIR/.bin/setup/common.sh"
 # --- flags ---
 #   --force          re-run every step
 #   --profile <tier> override the profile from the prep marker (core|dev|desktop)
+#   --work           also install work-machine tools (agency, etc.)
 #   reset            clear recorded step state and exit
 SETUP_PROFILE_OVERRIDE=""
+SETUP_WORK=false
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --force)     SETUP_FORCE=true; shift ;;
         --profile)   SETUP_PROFILE_OVERRIDE="$2"; shift 2 ;;
         --profile=*) SETUP_PROFILE_OVERRIDE="${1#*=}"; shift ;;
+        --work)      SETUP_WORK=true; shift ;;
         reset)       reset_steps; exit 0 ;;
         *)           shift ;;
     esac
@@ -141,6 +144,11 @@ main() {
         step talosctl     dev  all   install_talosctl
         step git-hooks    core all   setup_git_hooks
         step shell-zsh    core all   change_shell_to_zsh
+    fi
+
+    # Work-machine tools (agency, etc.) — only when --work is passed.
+    if [[ "$SETUP_WORK" == "true" ]]; then
+        step work-tools core all install_work_tools
     fi
 
     # Clean up sudo keepalive


### PR DESCRIPTION
Adds a `--work` flag to `setup.sh`. When passed, a new `work-tools` step
sources `scripts/setup-work-tools.sh` from the private personal-notes repo,
keeping internal MS endpoints out of public dotfiles.

- No-op (skips with a message) if the script is absent, so `--work` is safe
  on any machine.
- Override the path via `WORK_TOOLS_SCRIPT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)