### PR TITLE
Convert dotfiles to bare+worktree, stow from main worktree

### DIFF
--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -198,7 +198,7 @@ detect_distro() {
 if [[ -f "$_COMMON_DIR/regular-repos.zsh" ]]; then
     source "$_COMMON_DIR/regular-repos.zsh"
 else
-    REGULAR_CLONE_REPOS=(dotfiles personal-notes eduuh notes bn)  # nvim is bare+worktree (see regular-repos.zsh)
+    REGULAR_CLONE_REPOS=(personal-notes eduuh notes bn)  # nvim + dotfiles are bare+worktree (see regular-repos.zsh)
 fi
 
 # Repos that should live on the Windows filesystem when on WSL
@@ -882,7 +882,11 @@ install_nvm() {
 }
 
 setup_symlinks() {
-    local dotfiles_dir=~/projects/dotfiles
+    # dotfiles is a bare+worktree repo: stow always from the main worktree so the
+    # $HOME symlinks stay stable no matter which worktree you're editing in. Fall
+    # back to a flat ~/projects/dotfiles for entrypoints that still clone flat.
+    local dotfiles_dir=~/projects/worktree/dotfiles/main
+    [ -d "$dotfiles_dir" ] || dotfiles_dir=~/projects/dotfiles
 
     echo "Stowing dotfiles from $dotfiles_dir..."
     cd "$dotfiles_dir"
@@ -909,7 +913,8 @@ setup_personal_notes_stow() {
 
 setup_git_hooks() {
     echo "Setting up git hooks for all projects..."
-    local hook_source="$HOME/projects/dotfiles/.bin/git-hooks/pre-push"
+    local hook_source="$HOME/projects/worktree/dotfiles/main/.bin/git-hooks/pre-push"
+    [ -f "$hook_source" ] || hook_source="$HOME/projects/dotfiles/.bin/git-hooks/pre-push"
 
     if [ ! -f "$hook_source" ]; then
         track_failure "git-hooks" "Pre-push hook not found at $hook_source"
@@ -926,9 +931,9 @@ setup_git_hooks() {
         fi
     done
 
-    # Regular clones (dotfiles, personal-notes). nvim is bare+worktree — its hook
-    # is installed by the ~/projects/bare/*.git loop above.
-    for project in dotfiles personal-notes; do
+    # Regular clones (personal-notes). nvim and dotfiles are bare+worktree — their
+    # hooks are installed by the ~/projects/bare/*.git loop above.
+    for project in personal-notes; do
         local git_dir=~/projects/"$project"/.git
         if [ -d "$git_dir" ]; then
             local hook_dir="$git_dir/hooks"

--- a/.bin/setup/regular-repos.zsh
+++ b/.bin/setup/regular-repos.zsh
@@ -8,11 +8,11 @@
 # Rule of thumb: tools/config you don't branch-develop are flat; project repos
 # where you do feature-branch work are bare+worktree.
 
-# nvim is intentionally NOT here: its config is branch-developed (main/shellcmd),
-# so it clones bare + worktree like project repos, with ~/.config/nvim → its main
+# nvim and dotfiles are intentionally NOT here: their configs are branch-developed,
+# so they clone bare + worktree like project repos. dotfiles is stowed from its main
+# worktree (~/projects/worktree/dotfiles/main); nvim links ~/.config/nvim → its main
 # worktree. See _setup_nvim_config in common.sh.
 REGULAR_CLONE_REPOS=(
-    dotfiles
     personal-notes
     eduuh
     notes

--- a/.bin/wt
+++ b/.bin/wt
@@ -11,7 +11,7 @@ set -e
 if [[ -f "${0:A:h}/setup/regular-repos.zsh" ]]; then
     source "${0:A:h}/setup/regular-repos.zsh"
 else
-    REGULAR_CLONE_REPOS=(dotfiles)  # nvim is bare+worktree (see regular-repos.zsh)
+    REGULAR_CLONE_REPOS=(personal-notes eduuh notes bn)  # nvim + dotfiles are bare+worktree (see regular-repos.zsh)
 fi
 
 # Project layout. Defaults to ~/projects (fast ext4). $WT_ROOT lets a wrapper

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,6 +5,12 @@
 # git + zsh exist, clones the (public) dotfiles over https WITHOUT submodules
 # (private submodules need auth, which prep establishes), then hands off.
 #
+# dotfiles is cloned into the bare + worktree layout (like every other repo):
+#   ~/projects/bare/dotfiles.git          bare repo
+#   ~/projects/worktree/dotfiles/main     main worktree (stow source, prep runs here)
+# so you can `wt add feature/x` and work dotfiles across multiple worktrees while
+# the $HOME symlinks always stow from main.
+#
 # Run on a fresh machine:
 #   curl -fsSL https://raw.githubusercontent.com/eduuh/dotfiles/main/bootstrap.sh | bash
 #
@@ -13,7 +19,9 @@
 set -euo pipefail
 
 DOTFILES_REPO="${DOTFILES_REPO:-https://github.com/eduuh/dotfiles.git}"
-DOTFILES_DIR="${DOTFILES_DIR:-$HOME/projects/dotfiles}"
+PROJECT_ROOT="${PROJECT_ROOT:-$HOME/projects}"
+DOTFILES_BARE="$PROJECT_ROOT/bare/dotfiles.git"
+DOTFILES_MAIN="$PROJECT_ROOT/worktree/dotfiles/main"
 
 log() { printf '\033[1;36m[bootstrap]\033[0m %s\n' "$*"; }
 err() { printf '\033[1;31m[bootstrap]\033[0m %s\n' "$*" >&2; }
@@ -48,21 +56,28 @@ main() {
   ensure_pkg git  git
   ensure_pkg zsh  zsh
 
-  if [ -d "$DOTFILES_DIR/.git" ]; then
-    log "dotfiles already present at $DOTFILES_DIR — skipping clone"
+  if [ -e "$DOTFILES_MAIN/prep.sh" ]; then
+    log "dotfiles worktree already present at $DOTFILES_MAIN — skipping clone"
   else
-    log "cloning dotfiles → $DOTFILES_DIR (https, no submodules)"
-    mkdir -p "$(dirname "$DOTFILES_DIR")"
-    git clone "$DOTFILES_REPO" "$DOTFILES_DIR"
+    log "cloning dotfiles → bare + worktree (https, no submodules)"
+    mkdir -p "$(dirname "$DOTFILES_BARE")" "$(dirname "$DOTFILES_MAIN")"
+    git clone --bare "$DOTFILES_REPO" "$DOTFILES_BARE"
+    # Track all branches so `wt add` can check out any of them later.
+    git --git-dir="$DOTFILES_BARE" config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+    git --git-dir="$DOTFILES_BARE" fetch origin
+    local def
+    def=$(git --git-dir="$DOTFILES_BARE" symbolic-ref --short HEAD 2>/dev/null || echo main)
+    git --git-dir="$DOTFILES_BARE" worktree add "$PROJECT_ROOT/worktree/dotfiles/$def" "$def"
+    DOTFILES_MAIN="$PROJECT_ROOT/worktree/dotfiles/$def"
   fi
 
   log "handing off to prep (Phase 1)…"
   # Restore a real TTY for prep's interactive prompts (curl | bash leaves stdin
   # on the pipe). Fall back to a plain exec where there's no controlling tty.
   if [ -e /dev/tty ]; then
-    exec zsh "$DOTFILES_DIR/prep.sh" "$@" < /dev/tty
+    exec zsh "$DOTFILES_MAIN/prep.sh" "$@" < /dev/tty
   else
-    exec zsh "$DOTFILES_DIR/prep.sh" "$@"
+    exec zsh "$DOTFILES_MAIN/prep.sh" "$@"
   fi
 }
 

--- a/docs/tmux.md
+++ b/docs/tmux.md
@@ -2,7 +2,7 @@
 
 Prefix: **`C-Space`** (Ctrl+Space)
 
-The workflow: one **session per repo**, one **window per worktree**. Sessions are named after the bare repo (e.g. `tracker`, `kube-homelab`); windows are named after the branch (e.g. `feat-auth`). Plain clones like `dotfiles` get a single `main` window.
+The workflow: one **session per repo**, one **window per worktree**. Sessions are named after the bare repo (e.g. `tracker`, `kube-homelab`); windows are named after the branch (e.g. `feat-auth`). Plain (non-bare) clones get a single `main` window; bare repos like `dotfiles` open a window per worktree.
 
 ## Sessions
 
@@ -20,7 +20,7 @@ The workflow: one **session per repo**, one **window per worktree**. Sessions ar
 | `o` | **Go to or create worktree.** fzf list of existing worktrees. Select one → opens as window. Type a new name + Enter → creates worktree from latest `main`, opens as window. |
 | `X` | Remove current window's worktree + kill the window. Refuses `main`/`master`. Prompts for `--force` if dirty. |
 
-In a non-bare session (e.g. `dotfiles`), `o` just opens/selects a `main` window at the repo path.
+In a non-bare session, `o` just opens/selects a `main` window at the repo path.
 
 ## Windows
 

--- a/prep.sh
+++ b/prep.sh
@@ -37,13 +37,16 @@ default_profile() {
 }
 
 main() {
-  local target profile="" arg_profile=""
+  local target profile="" arg_profile="" run_setup=true
 
   # --- parse args ---
+  #   --profile <tier>  override the profile (core|dev|desktop)
+  #   --prep-only       stop after prep; don't chain into setup.sh
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --profile)   arg_profile="$2"; shift 2 ;;
       --profile=*) arg_profile="${1#*=}"; shift ;;
+      --prep-only) run_setup=false; shift ;;
       *)           shift ;;
     esac
   done
@@ -81,13 +84,18 @@ main() {
 
   print_failure_summary
 
+  if [[ "$run_setup" != "true" ]]; then
+    echo ""
+    echo "Prep complete (--prep-only). Run the unattended install when ready:"
+    echo "    cd $SCRIPT_DIR && ./setup.sh"
+    return 0
+  fi
+
   echo ""
-  echo "Prep complete. The interactive part is done — the rest is unattended:"
+  echo "Prep complete — the interactive part is done. Handing off to the"
+  echo "unattended install (setup.sh); walk away, it won't prompt."
   echo ""
-  echo "    cd $SCRIPT_DIR && ./setup.sh"
-  echo ""
-  echo "(Once setup.sh becomes the Phase 2 runner it will read $READY_MARKER"
-  echo " for target+profile and skip these prompts. For now run it as-is.)"
+  exec zsh "$SCRIPT_DIR/setup.sh" --profile "$profile"
 }
 
 main "$@"

--- a/readme.md
+++ b/readme.md
@@ -12,17 +12,23 @@
 
 ## Setup
 
-The setup script runs under zsh, so install it first if it's not already present:
+Fresh machine — one command bootstraps everything:
 
 ```bash
-sudo apt-get install -y zsh git
+curl -fsSL https://raw.githubusercontent.com/eduuh/dotfiles/main/bootstrap.sh | bash
 ```
 
-Then clone and run:
+It installs `git`/`zsh`, clones dotfiles into the bare + worktree layout
+(`~/projects/bare/dotfiles.git` + `~/projects/worktree/dotfiles/main`), then hands
+off to the attended `prep.sh` (sudo, GitHub auth) and the unattended `setup.sh`.
+Symlinks are always stowed from the `main` worktree, so you can `wt add
+feature/x` and edit dotfiles in multiple worktrees without disturbing them.
+
+Already cloned? Run the phases directly from the main worktree:
 
 ```bash
-git clone https://github.com/eduuh/dotfiles.git ~/projects/dotfiles
-cd ~/projects/dotfiles && ./setup.sh
+cd ~/projects/worktree/dotfiles/main
+./prep.sh && ./setup.sh
 ```
 
 Python setup (venv + pynvim/requests, and on Ubuntu the `python3.10` /
@@ -66,7 +72,7 @@ On macOS, all Homebrew packages are managed via a [`Brewfile`](Brewfile).
 
 ## Key Tools
 
-- **`tat`** — Tmux session picker with zoxide frecency and fzf preview
+- **`tat`** — Tmux session picker (lives in the `bn` workflow submodule)
 - **`wt`** — Git worktree manager for bare repos (`wt clone`, `wt add`, `wt list`, `wt remove`)
 - **`bn`** — Branch notes manager for per-branch task tracking
 - **`ssh-export`** — Copy SSH key setup script to clipboard for bootstrapping new environments
@@ -92,4 +98,4 @@ Setup auto-detects Codespaces (`$CODESPACES=true`) and adjusts:
 
 ## Related
 
-[win-dot](https://github.com/eduuh/win-dot) · [arch-dotfiles](https://github.com/eduuh/arch-dotfiles) · [thetrader](https://github.com/eduuh/thetrader)
+[win-dot](https://github.com/eduuh/win-dot) · [arch-dotfiles](https://github.com/eduuh/arch-dotfiles)


### PR DESCRIPTION
dotfiles was a flat regular clone at `~/projects/dotfiles`. This converts it to the same bare + worktree layout every other repo uses (the nvim pattern), so it can be branch-developed across multiple worktrees while the `$HOME` stow symlinks always come from the **main** worktree.

## Changes
- **Clone layout**: drop `dotfiles` from `REGULAR_CLONE_REPOS` (`regular-repos.zsh`, `common.sh`, `wt`) → clones bare + worktree.
- **Stow source**: `setup_symlinks` + `setup_git_hooks` source from `~/projects/worktree/dotfiles/main` (fallback to flat path for entrypoints that still clone flat).
- **bootstrap.sh**: clones `--bare` + adds the main worktree, runs prep from there.
- **prep.sh**: now `exec`s `setup.sh` after the attended phase; `--prep-only` opts out.
- **docs**: bootstrap-first readme, worktree layout, simplified `tat`, dropped `thetrader`; fixed plain-clone examples in `docs/tmux.md`.

## Verified
Migrated the dev machine live: all 24 `$HOME` symlinks repoint to `…/dotfiles/main` (none broken); `bn`, `wt list`, and `.tmux.conf` (via the bn-repo submodule) all resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)