### PR TITLE
feat(setup): pull the bn release instead of building from source

### DIFF
--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -742,8 +742,10 @@ build_bn() {
     # Install the Rust bn from the bn-repo submodule via its own install.sh. It
     # builds bn + bn-mcp into $APP_BIN_DIR and registers the bn-mcp stdio server
     # for Claude Code + Copilot (idempotent — --force re-runs this step). --core
-    # skips bn's tmux layer (dotfiles owns tmux); BN_BUILD_FROM_SOURCE=1 builds the
-    # pinned submodule rather than pulling a release, so binaries match this commit.
+    # skips bn's tmux layer (dotfiles owns tmux). install.sh pulls the prebuilt release
+    # (via authenticated `gh`), so every machine gets the same binary without compiling;
+    # it builds the pinned submodule only as a fallback when no release/gh is available.
+    # Cut a new bn release (tag vX.Y.Z) to advance the deployed binary.
     # BN_BIN_DIR keeps the install off ~/.bin (a tracked symlink) — the ~/.bin/bn
     # shim is shadowed by the real binary earlier on PATH.
     if [[ $CODESPACES == "true" ]]; then
@@ -758,7 +760,7 @@ build_bn() {
 
     echo "Installing Rust bn (+ bn-mcp, + global MCP registration) → $APP_BIN_DIR…"
     if ! (
-        export BN_BIN_DIR="$APP_BIN_DIR" BN_BUILD_FROM_SOURCE=1
+        export BN_BIN_DIR="$APP_BIN_DIR"
         run_app_installer "$_COMMON_DIR/../bn-repo/install.sh" --core
     ); then
         track_failure "bn" "Failed to install Rust bn"


### PR DESCRIPTION
Drops `BN_BUILD_FROM_SOURCE=1` from `build_bn` so `setup.sh`'s `install.sh` **pulls the prebuilt bn release** (now private-repo-safe via `gh`, [bn#31](https://github.com/eduuh/bn/pull/31)) instead of compiling. Every machine gets the same binary without cargo — ending the per-session `~/.bin/bn` drift. Falls back to a source build only when no release/gh is available.

Also bumps `.bin/bn-repo` to the bn `main` carrying the install.sh fix.

**Model:** advance the deployed binary by cutting a new bn release tag (e.g. `v0.1.1`).