### PR TITLE
fix(zsh): drop the bn alias so PATH resolves the release binary

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -24,7 +24,6 @@ alias l='ls -CF'
 alias yolo='claude --dangerously-skip-permissions'
 alias po="$HOME/.bin/pkg-open.sh"
 alias nvimd='nvim -c "DiffviewOpen origin/main"'
-alias bn="$HOME/.bin/bn"
 
 # Load NVM
 export NVM_DIR="$HOME/.nvm"


### PR DESCRIPTION
`alias bn=$HOME/.bin/bn` bypassed PATH, pinning bn to the stale dispatcher shim and shadowing the release binary build_bn installs to `~/.local/bin`. Dropping it lets bn resolve via PATH to the release (the shim remains an on-PATH fallback). Completes the release-pull chain (bn#31 + dotfiles#124).