### PR TITLE
fix(bn): shim resolves the release binary before the bash fallback

### DIFF
--- a/.bin/bn
+++ b/.bin/bn
@@ -1,9 +1,16 @@
 #!/usr/bin/env sh
-# bn dispatcher. Prefer the compiled Rust binary; fall back to the bash bn.
-# The Rust binary is built from the bn-repo submodule by setup (cargo build).
-# Where Rust isn't built (e.g. Codespaces, which skip the toolchain) the bash
-# bn takes over, so `bn` always resolves to a working implementation.
+# bn dispatcher for the dotfiles-tracked ~/.bin (a symlinked dir that can't hold the
+# real, machine-specific binary). Resolve the first Rust bn that exists, else the bash
+# fallback. Order matters — the bash bn lacks newer commands (e.g. `tmux-agent`, used by
+# the Claude Stop hooks), so a real binary MUST win whenever one is present:
+#   1. ~/.local/bin/bn          — where bn-repo/install.sh deploys (download or build).
+#                                 This is the normal path: install prefers a prebuilt
+#                                 release and never touches the submodule's target/.
+#   2. bn-repo/target/release/bn — a local dev `cargo build` in the submodule.
+#   3. bn-bash                  — the bash implementation (Codespaces / no Rust toolchain).
+# Both 1 and 2 are real binary copies (never symlinks back here), so no recursion.
 d=$(dirname "$0")
-rs="$d/bn-repo/target/release/bn"
-[ -x "$rs" ] && exec "$rs" "$@"
+for rs in "$HOME/.local/bin/bn" "$d/bn-repo/target/release/bn"; do
+  [ -x "$rs" ] && exec "$rs" "$@"
+done
 exec "$d/bn-bash" "$@"


### PR DESCRIPTION
## Problem

The Claude Code Stop hooks call `\$HOME/.bin/bn tmux-agent ...` — the dotfiles **shim** directly, not the PATH `bn`. So #125 (dropping the bn alias) didn't reach them.

The shim only checked the submodule's `target/release/bn`, which `install.sh` never builds on the normal path (it deploys a prebuilt release into `~/.local/bin`). So `\$HOME/.bin/bn` fell through to the bash `bn`, which lacks `tmux-agent`, and every Stop hook errored:

```
Stop hook error: Unknown command: tmux-agent
```

## Fix

The shim now resolves the same binary `install.sh` deploys — `~/.local/bin/bn` first, then the submodule dev build, then bash. A real binary wins whenever one is present.

Verified `\$HOME/.bin/bn tmux-agent working` exits 0 and `sh -x` shows it execs `~/.local/bin/bn`, not bash.

Companion to #125: that fixed interactive `bn` (via PATH); this fixes the hardcoded `\$HOME/.bin/bn` in the hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)