### PR TITLE
chore(setup): clone bn bare+worktree like nvim and dotfiles

### DIFF
--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -198,7 +198,7 @@ detect_distro() {
 if [[ -f "$_COMMON_DIR/regular-repos.zsh" ]]; then
     source "$_COMMON_DIR/regular-repos.zsh"
 else
-    REGULAR_CLONE_REPOS=(personal-notes eduuh notes bn)  # nvim + dotfiles are bare+worktree (see regular-repos.zsh)
+    REGULAR_CLONE_REPOS=(personal-notes eduuh notes)  # nvim, dotfiles, bn are bare+worktree (see regular-repos.zsh)
 fi
 
 # Repos that should live on the Windows filesystem when on WSL

--- a/.bin/setup/regular-repos.zsh
+++ b/.bin/setup/regular-repos.zsh
@@ -8,13 +8,12 @@
 # Rule of thumb: tools/config you don't branch-develop are flat; project repos
 # where you do feature-branch work are bare+worktree.
 
-# nvim and dotfiles are intentionally NOT here: their configs are branch-developed,
-# so they clone bare + worktree like project repos. dotfiles is stowed from its main
-# worktree (~/projects/worktree/dotfiles/main); nvim links ~/.config/nvim → its main
-# worktree. See _setup_nvim_config in common.sh.
+# nvim, dotfiles, and bn are intentionally NOT here: they're branch-developed (feature
+# branches, PRs), so they clone bare + worktree like project repos. dotfiles is stowed
+# from its main worktree (~/projects/worktree/dotfiles/main); nvim links ~/.config/nvim →
+# its main worktree. See _setup_nvim_config in common.sh.
 REGULAR_CLONE_REPOS=(
     personal-notes
     eduuh
     notes
-    bn
 )

--- a/.bin/wt
+++ b/.bin/wt
@@ -11,7 +11,7 @@ set -e
 if [[ -f "${0:A:h}/setup/regular-repos.zsh" ]]; then
     source "${0:A:h}/setup/regular-repos.zsh"
 else
-    REGULAR_CLONE_REPOS=(personal-notes eduuh notes bn)  # nvim + dotfiles are bare+worktree (see regular-repos.zsh)
+    REGULAR_CLONE_REPOS=(personal-notes eduuh notes)  # nvim, dotfiles, bn are bare+worktree (see regular-repos.zsh)
 fi
 
 # Project layout. Defaults to ~/projects (fast ext4). $WT_ROOT lets a wrapper


### PR DESCRIPTION
## Why

`bn` is branch-developed — feature branches and PRs, same as `nvim` and `dotfiles`. The rule in `regular-repos.zsh` is "project repos where you do feature-branch work are bare+worktree", so `bn` was misclassified as a flat clone.

## Change

Remove `bn` from the source-of-truth `regular-repos.zsh` and the two fallback lists (`.bin/wt`, `common.sh`). A fresh `setup` now clones `bn` bare at `~/projects/bare/bn.git` with a `main` worktree at `~/projects/worktree/bn/main`, via the same `wt clone` path nvim/dotfiles use.

The existing dev clone at `~/projects/bn` is migrated to the new layout locally (not part of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)