### PR TITLE
Defence: pre-commit guard against working on main

### DIFF
--- a/.bin/git-hooks/pre-commit
+++ b/.bin/git-hooks/pre-commit
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Defence: never commit on a main branch, and never commit in a stow-source main
+# worktree. All real work happens in a dedicated feature worktree (wt add <branch>),
+# so `main` worktrees stay clean and branch work never pollutes them.
+#
+# Installed into every bare repo's shared hooks dir by setup_git_hooks, so it runs
+# for commits in all worktrees. Override a single commit with `git commit --no-verify`.
+
+branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || echo DETACHED)
+top=$(git rev-parse --show-toplevel 2>/dev/null)
+
+block() {
+    printf '\n🚫  \033[1;31mPROTECTED: %s\033[0m\n' "$1" >&2
+    shift
+    for line in "$@"; do printf '   %s\n' "$line" >&2; done
+    printf '   Override once with: \033[1mgit commit --no-verify\033[0m\n\n' >&2
+    exit 1
+}
+
+# 1. Never work on main/master directly — create a feature branch + worktree.
+if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+    block "no commits on '$branch'" \
+        "Work in a feature worktree instead:" \
+        "    wt add -b <branch> $branch     # new worktree off $branch" \
+        "then commit there. PRs only into $branch."
+fi
+
+# 2. Never develop in a stow-source main worktree (~/.../worktree/<repo>/main),
+#    even on a feature branch — it would move the symlink source's HEAD.
+case "$top" in
+    */worktree/*/main)
+        block "this is the main (stow-source) worktree" \
+            "$top" \
+            "It must stay on 'main'. Do this branch's work in its own worktree:" \
+            "    wt add $branch" \
+            "Restore this one with:  git switch main"
+        ;;
+esac
+
+exit 0

--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -915,22 +915,28 @@ setup_personal_notes_stow() {
 
 setup_git_hooks() {
     echo "Setting up git hooks for all projects..."
-    local hook_source="$HOME/projects/worktree/dotfiles/main/.bin/git-hooks/pre-push"
-    [ -f "$hook_source" ] || hook_source="$HOME/projects/dotfiles/.bin/git-hooks/pre-push"
+    local hook_src_dir="$HOME/projects/worktree/dotfiles/main/.bin/git-hooks"
+    [ -d "$hook_src_dir" ] || hook_src_dir="$HOME/projects/dotfiles/.bin/git-hooks"
 
-    if [ ! -f "$hook_source" ]; then
-        track_failure "git-hooks" "Pre-push hook not found at $hook_source"
+    if [ ! -d "$hook_src_dir" ]; then
+        track_failure "git-hooks" "Hook source dir not found at $hook_src_dir"
         return 0
     fi
 
-    # Bare repos in ~/projects/bare/*.git
+    # Symlink every hook in .bin/git-hooks/ into a repo's hooks dir (pre-push,
+    # pre-commit, …). Adding a new hook there needs no change here.
+    _link_hooks() {
+        local dest="$1" hook
+        mkdir -p "$dest"
+        for hook in "$hook_src_dir"/*(N.); do
+            ln -sf "$hook" "$dest/${hook:t}" || track_failure "git-hooks" "Failed to link ${hook:t} into $dest"
+        done
+    }
+
+    # Bare repos — hooks are shared across all their worktrees.
     for bare in ~/projects/bare/*.git(N/); do
-        local hook_dir="$bare/hooks"
-        echo "Installing pre-push hook in $(basename "$bare")..."
-        mkdir -p "$hook_dir"
-        if ! ln -sf "$hook_source" "$hook_dir/pre-push"; then
-            track_failure "git-hooks" "Failed to install hook in $(basename "$bare")"
-        fi
+        echo "Installing hooks in $(basename "$bare")..."
+        _link_hooks "$bare/hooks"
     done
 
     # Regular clones (personal-notes). nvim and dotfiles are bare+worktree — their
@@ -938,12 +944,8 @@ setup_git_hooks() {
     for project in personal-notes; do
         local git_dir=~/projects/"$project"/.git
         if [ -d "$git_dir" ]; then
-            local hook_dir="$git_dir/hooks"
-            echo "Installing pre-push hook in $project..."
-            mkdir -p "$hook_dir"
-            if ! ln -sf "$hook_source" "$hook_dir/pre-push"; then
-                track_failure "git-hooks" "Failed to install hook in $project"
-            fi
+            echo "Installing hooks in $project..."
+            _link_hooks "$git_dir/hooks"
         fi
     done
 }


### PR DESCRIPTION
Enforces the worktree-first workflow: all real work happens in a dedicated feature worktree, never in a `main` checkout.

## pre-commit hook (`.bin/git-hooks/pre-commit`)
Blocks a commit when:
1. the branch is `main`/`master` (PRs only), or
2. it's made in a stow-source `*/worktree/*/main` worktree, even on a feature branch (would move the symlink source's HEAD).

Escape hatch: `git commit --no-verify`. Tested: blocks in the `main` worktree on `main`, allows in a feature worktree.

## setup_git_hooks
Now symlinks **every** file in `.bin/git-hooks/` (pre-push, pre-commit, future hooks) into each repo's hooks dir, instead of hardcoding `pre-push`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)