### PR TITLE
Capture model under Copilot CLI

### DIFF
--- a/.bin/bn-capture-model.sh
+++ b/.bin/bn-capture-model.sh
@@ -1,36 +1,47 @@
 #!/usr/bin/env bash
-# Claude Code UserPromptSubmit hook — capture the live model for bn.
+# UserPromptSubmit hook for Claude Code AND GitHub Copilot CLI — capture the live
+# model into the file bn's detect_model() reads, so the branch note's `models` list
+# records mid-session model switches (the model isn't in the env; harness hooks don't
+# carry it). Reads the hook JSON on stdin. Always exits 0 — never block a prompt.
 #
-# The model isn't in the environment and Claude Code hooks don't carry it past
-# SessionStart, so mid-session switches (/model, fast-mode) are invisible to env.
-# But the transcript records each assistant message's model. This hook reads the
-# newest one and writes it to the per-session file bn's detect_model() reads
-# (<state>/model-<session_id>), so the branch note's `models` list tracks switches.
-#
-# Wired as a UserPromptSubmit hook (fires every prompt). Always exits 0 — a capture
-# failure must never block the prompt. No-op without jq or a usable transcript.
+#   Claude Code: payload has .transcript_path + .session_id; the newest assistant
+#     message in the transcript carries .message.model. Keyed by session id
+#     (bn reads via $CLAUDE_CODE_SESSION_ID).
+#   Copilot CLI: payload has .sessionId + .cwd; the newest assistant.message in
+#     ~/.copilot/session-state/<sessionId>/events.jsonl carries .data.model. Copilot
+#     exposes no session id to its tool env, so key by cwd (bn reads via its own cwd).
 
 input=$(cat)
 command -v jq >/dev/null 2>&1 || exit 0
 
-sid=$(printf '%s' "$input" | jq -r '.session_id // empty' 2>/dev/null)
+# bn state dir: BN_STATE_DIR → XDG_STATE_HOME/bn → ~/.local/state/bn (mirror state_dir()).
+if [ -n "${BN_STATE_DIR:-}" ]; then state="$BN_STATE_DIR"
+elif [ -n "${XDG_STATE_HOME:-}" ]; then state="$XDG_STATE_HOME/bn"
+else state="$HOME/.local/state/bn"; fi
+
+write_model() { # <basename> <model>
+    [ -n "$2" ] || return 0
+    mkdir -p "$state" 2>/dev/null || return 0
+    printf '%s' "$2" > "$state/$1" 2>/dev/null || true
+}
+
+# --- Claude Code: model from the transcript, keyed by session id ---
 tp=$(printf '%s' "$input" | jq -r '.transcript_path // empty' 2>/dev/null)
-[ -n "$sid" ] && [ -n "$tp" ] && [ -f "$tp" ] || exit 0
-
-# Newest assistant message wins (transcript is append-only JSONL).
-model=$(tac "$tp" 2>/dev/null | grep -m1 '"type":"assistant"' \
-    | jq -r '.message.model // empty' 2>/dev/null)
-[ -n "${model:-}" ] || exit 0
-
-# Mirror bn's state_dir(): BN_STATE_DIR → XDG_STATE_HOME/bn → ~/.local/state/bn.
-if [ -n "${BN_STATE_DIR:-}" ]; then
-    state="$BN_STATE_DIR"
-elif [ -n "${XDG_STATE_HOME:-}" ]; then
-    state="$XDG_STATE_HOME/bn"
-else
-    state="$HOME/.local/state/bn"
+if [ -n "$tp" ] && [ -f "$tp" ]; then
+    sid=$(printf '%s' "$input" | jq -r '.session_id // empty' 2>/dev/null)
+    model=$(tac "$tp" 2>/dev/null | grep -m1 '"type":"assistant"' \
+        | jq -r '.message.model // empty' 2>/dev/null)
+    [ -n "$sid" ] && write_model "model-$sid" "$model"
+    exit 0
 fi
 
-mkdir -p "$state" 2>/dev/null || exit 0
-printf '%s' "$model" > "$state/model-$sid" 2>/dev/null || true
+# --- Copilot CLI: model from the session events, keyed by cwd ---
+sid=$(printf '%s' "$input" | jq -r '.sessionId // empty' 2>/dev/null)
+cwd=$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null)
+ev="$HOME/.copilot/session-state/$sid/events.jsonl"
+if [ -n "$sid" ] && [ -n "$cwd" ] && [ -f "$ev" ]; then
+    model=$(tac "$ev" 2>/dev/null | grep -m1 '"type":"assistant.message"' \
+        | jq -r '.data.model // empty' 2>/dev/null)
+    write_model "model-cwd-$(printf '%s' "$cwd" | tr '/' '_')" "$model"
+fi
 exit 0

--- a/.copilot/hooks/bn-model.json
+++ b/.copilot/hooks/bn-model.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "hooks": {
+    "userPromptSubmitted": [
+      {
+        "type": "command",
+        "bash": "$HOME/.bin/bn-capture-model.sh",
+        "timeoutSec": 5
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Generalizes `bn-capture-model.sh` to both harnesses and adds a Copilot `userPromptSubmitted` hook (`.copilot/hooks/bn-model.json`, install to `~/.copilot/hooks/`).

- Claude: transcript → session-keyed file (unchanged).
- Copilot: `~/.copilot/session-state/<sessionId>/events.jsonl` `.data.model` → cwd-keyed file (Copilot has no session id in the tool env; pairs with bn #37).

Tested against a real Copilot session: `model-cwd-<cwd>` = `claude-opus-4.8`. Claude path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)