### PR TITLE
fix(wt): delete branch reliably when cleanup runs from inside the worktree

### DIFF
--- a/.bin/wt
+++ b/.bin/wt
@@ -483,6 +483,11 @@ cleanup_one() {
         return 1
     fi
 
+    # If we were inside the worktree, this process's CWD is now a deleted directory — git,
+    # rmdir, and bn would all fail to read it. Step out to a stable dir before the rest of the
+    # cleanup (this affects only this subprocess, not the caller's shell).
+    $cwd_inside && { cd "$WORKTREE_DIR" 2>/dev/null || cd "$HOME" || cd /; }
+
     git --git-dir="$bare" branch -D "$branch" 2>/dev/null || true
 
     local repo_dir


### PR DESCRIPTION
## Bug

`wt cleanup` is normally run **from inside** the worktree it removes. After `git worktree remove`, the script's CWD is a now-deleted directory, so every following command (`git branch -D`, `rmdir`, `bn prune`) failed with a getcwd error — silenced by `2>/dev/null || true`. Result: **the branch was never deleted** (you'd get the `[gone]` branch the README warns about).

Pre-existing, but surfaced while validating the close-window teardown (#133).

## Fix

After a successful `git worktree remove`, when we were inside the worktree, `cd` to a stable directory (`WORKTREE_DIR`) before the rest of the cleanup. Affects only the `wt` subprocess, not the caller's shell.

## Validation

Reproduced in an isolated `WT_ROOT` sandbox: running `wt cleanup --force` from inside a throwaway worktree left the branch undeleted before the fix; after the fix, all steps succeed —
```
worktree removed?   yes ✓
branch deleted?     yes ✓
repo dir rmdir'd?   yes ✓
note status:        closed
```
Plus confirmed the `git`-from-deleted-CWD failure directly (`fatal: Unable to read current working directory`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)