### PR TITLE
fix(bn-hook): resolve state dir via `bn --state-dir`

### DIFF
--- a/.bin/bn-capture-model.sh
+++ b/.bin/bn-capture-model.sh
@@ -14,10 +14,10 @@
 input=$(cat)
 command -v jq >/dev/null 2>&1 || exit 0
 
-# bn state dir: BN_STATE_DIR → XDG_STATE_HOME/bn → ~/.local/state/bn (mirror state_dir()).
+# bn state dir: BN_STATE_DIR wins; else ask bn (resolves <personal_root>/<machine>/state).
 if [ -n "${BN_STATE_DIR:-}" ]; then state="$BN_STATE_DIR"
-elif [ -n "${XDG_STATE_HOME:-}" ]; then state="$XDG_STATE_HOME/bn"
-else state="$HOME/.local/state/bn"; fi
+else state=$(bn --state-dir 2>/dev/null); fi
+[ -n "$state" ] || exit 0
 
 write_model() { # <basename> <model>
     [ -n "$2" ] || return 0


### PR DESCRIPTION
bn moved its state dir from the machine-local `~/.local/state/bn` into the synced notes repo (`<personal_root>/<machine>/state`) — see eduuh/bn#61.

This updates the `bn-capture-model.sh` UserPromptSubmit hook to resolve the path from `bn --state-dir` instead of hardcoding the old location, so model captures land where bn now reads them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)