### PR TITLE
feat: PATH -> ~/.bn/bin; drop TPM bootstrap (bn self-contained)

### DIFF
--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -582,21 +582,8 @@ ensure_tmux_version() {
     echo "tmux $(tmux -V) installed successfully."
 }
 
-install_tmux_plugins() {
-    local target_dir="$HOME/.tmux/plugins/tpm"
-
-    if [ -d "$target_dir" ]; then
-        echo "TPM is already installed at $target_dir."
-        return 0
-    fi
-
-    echo "Cloning TPM repository..."
-    if git clone https://github.com/tmux-plugins/tpm "$target_dir"; then
-        echo "TPM has been successfully installed at $target_dir."
-    else
-        track_failure "tmux" "Failed to clone TPM repository"
-    fi
-}
+# TPM removed: bn vendors its tmux plugins (tmux-resurrect + tmux-continuum) in-repo and
+# sources them directly from its tmux.conf, so there is no plugin manager to bootstrap.
 
 install_neovim() {
     echo "Installing Neovim from GitHub releases..."

--- a/.bin/setup/termux.sh
+++ b/.bin/setup/termux.sh
@@ -48,7 +48,6 @@ setup_termux() {
     update_system
     install_common_packages
     install_termux_specific_packages
-    install_tmux_plugins
     change_shell_to_zsh
     setup_symlinks
 }

--- a/.zshenv
+++ b/.zshenv
@@ -1,7 +1,8 @@
 [ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
 
-# User-local tools on PATH for ALL shells, not just interactive ones: fzf/zoxide/nvim
-# live in ~/.local/bin, bn + workflow scripts in ~/.bin. Keeping this in .zshenv (not
-# .zshrc) lets non-interactive `zsh -c` — e.g. tmux popups — resolve them without paying
-# the full interactive-shell startup cost.
-export PATH="$HOME/.bin:$HOME/.local/bin:$PATH"
+# User-local tools on PATH for ALL shells, not just interactive ones: bn + its workflow
+# scripts live in ~/.bn/bin (bn's self-contained home), fzf/zoxide/nvim in ~/.local/bin,
+# legacy helpers in ~/.bin. ~/.bn/bin goes first so the bn there wins over any stale copy.
+# Keeping this in .zshenv (not .zshrc) lets non-interactive `zsh -c` — e.g. tmux popups —
+# resolve them without paying the full interactive-shell startup cost.
+export PATH="$HOME/.bn/bin:$HOME/.bin:$HOME/.local/bin:$PATH"

--- a/.zshrc
+++ b/.zshrc
@@ -1,5 +1,5 @@
-# Basic Path Setup
-export PATH="$HOME/.bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+# Basic Path Setup — ~/.bn/bin (bn's self-contained home) first, then legacy ~/.bin
+export PATH="$HOME/.bn/bin:$HOME/.bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 
 # Homebrew Setup
 if [ -f "/opt/homebrew/bin/brew" ]; then


### PR DESCRIPTION
Companions to the bn ~/.bn migration (eduuh/bn#199–201).

- **PATH**: prepend `$HOME/.bn/bin` in `.zshenv` + `.zshrc` so interactive `bn` resolves to bn's self-contained home (`~/.bn/bin`) instead of the legacy stow'd `~/.bin` copy.
- **TPM**: bn now vendors tmux-resurrect + tmux-continuum and sources them directly from its tmux.conf — remove the now-dead `install_tmux_plugins()` (TPM clone) and its termux call site.

`ensure_tmux_version` (tmux *binary* version mgmt) is intentionally kept.