### PR TITLE
chore(gitignore): ignore bn install.sh symlinks in .bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,14 @@
 # file — they don't belong in the dotfiles tree.
 .bin/bn
 .bin/bn-mcp
+# bn install.sh also symlinks these into .bin (pointing into the bn-repo checkout).
+# Machine-local install artifacts like the two above — not tracked.
+.bin/bn-bash
+.bin/bn-repo
+.bin/agent
+.bin/tat
+.bin/tatw
+.bin/wt-clone
 
 # bn cron systemd units. The source of truth is the bn repo (jobs/systemd/);
 # `jobs/systemd/install.sh` copies them here. Installed artifacts, not tracked.


### PR DESCRIPTION
`bn install.sh` symlinks `agent`, `tat`, `tatw`, `wt-clone`, `bn-bash`, `bn-repo` into `.bin/` (pointing into the bn-repo checkout). These are machine-local install artifacts — same class as the already-ignored `.bin/bn` and `.bin/bn-mcp` — so they shouldn't show as untracked or be committed. Adds them to `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)