### PR TITLE
fix(bn-progress-hook): use || true so empty tool count stays "0"

### DIFF
--- a/.bin/bn-progress-hook.sh
+++ b/.bin/bn-progress-hook.sh
@@ -18,8 +18,8 @@ FILES=0
 BASH=0
 if [[ -n "$TRANSCRIPT" && -f "$TRANSCRIPT" ]]; then
     TOOLS=$(jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "tool_use") | .name // empty' "$TRANSCRIPT" 2>/dev/null)
-    FILES=$(echo "$TOOLS" | grep -cE '^(Edit|Write|NotebookEdit)$' || echo 0)
-    BASH=$(echo "$TOOLS"  | grep -c '^Bash$' || echo 0)
+    FILES=$(echo "$TOOLS" | grep -cE '^(Edit|Write|NotebookEdit)$' || true)
+    BASH=$(echo "$TOOLS"  | grep -c '^Bash$' || true)
 fi
 
 parts=()


### PR DESCRIPTION
`grep -c` prints "0" and exits 1 on no match, so `|| echo 0` appended a
second "0", making FILES/BASH the two-line string "0\n0". The downstream
`(( FILES > 0 ))` then errored with "bad math expression". This hit every
session that ended with no Edit/Write/Bash tool use.

`|| true` swallows grep's exit-1 (required under set -euo pipefail) while
keeping grep's own correct "0" output.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
