### PR TITLE
Add copilot/claude yolo aliases with bn note + mcp init

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -21,7 +21,9 @@ alias grep='grep --color=auto'
 alias ll='ls -alF'
 alias la='ls -A'
 alias l='ls -CF'
-alias yolo='claude --dangerously-skip-permissions'
+yolo() { bn note >/dev/null 2>&1; command claude --dangerously-skip-permissions "$@"; }
+claude() { bn note >/dev/null 2>&1; command claude "$@"; }
+copilot() { bn note >/dev/null 2>&1; git rev-parse --is-inside-work-tree >/dev/null 2>&1 && bn mcp init copilot >/dev/null 2>&1; command copilot --yolo "$@"; }
 alias po="$HOME/.bin/pkg-open.sh"
 alias nvimd='nvim -c "DiffviewOpen origin/main"'
 


### PR DESCRIPTION
## Summary
- \`yolo\`/\`claude\`: run \`bn note\` before launching claude, ensuring the branch note exists before the session starts.
- \`copilot\`: run \`bn note\` and (when inside a git worktree) \`bn mcp init copilot\` before launching \`copilot --yolo\`, so MCP wiring is set up automatically for every repo instead of by hand.

🤖 Generated with [Copilot CLI](https://github.com/github/copilot-cli)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>