### PR TITLE
Add n8n docker-compose management aliases

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -36,6 +36,10 @@ tmux() {
     command tmux "$@"
   fi
 }
+alias n8n-up='(cd ~/projects/n8n && make up)'
+alias n8n-down='(cd ~/projects/n8n && make down)'
+alias n8n-logs='(cd ~/projects/n8n && make logs)'
+alias n8n-update='(cd ~/projects/n8n && make update)'
 
 # Load NVM
 export NVM_DIR="$HOME/.nvm"


### PR DESCRIPTION
## Summary
Adds \`n8n-up\`/\`n8n-down\`/\`n8n-logs\`/\`n8n-update\` aliases wrapping the Makefile in \`~/projects/n8n\`, which runs n8n via \`docker compose\` with:
- a persistent named volume (\`n8n_data\`, matching the original \`docker volume create n8n_data\`)
- \`restart: unless-stopped\` so it survives reboots/Docker Desktop restarts
- env-driven \`N8N_HOST\`/\`WEBHOOK_URL\` so it can be pointed at the machine's Tailscale MagicDNS name for reachability over the tailnet
- optional basic auth toggle (off by default, relying on Tailscale ACLs)

🤖 Generated with [Copilot CLI](https://github.com/github/copilot-cli)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>