### PR TITLE
Make bare tmux always attach to the planning session

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -26,6 +26,16 @@ claude() { bn note >/dev/null 2>&1; command claude "$@"; }
 copilot() { bn note >/dev/null 2>&1; git rev-parse --is-inside-work-tree >/dev/null 2>&1 && bn mcp init copilot >/dev/null 2>&1; command copilot --yolo "$@"; }
 alias po="$HOME/.bin/pkg-open.sh"
 alias nvimd='nvim -c "DiffviewOpen origin/main"'
+# Bare `tmux` (no args) always attaches to the persistent 'planning' session
+# instead of tmux's default of creating a fresh numbered session.
+tmux() {
+  if [ $# -eq 0 ]; then
+    command tmux attach -t planning 2>/dev/null || \
+      command tmux new-session -s planning -c "$HOME/projects/personal-notes"
+  else
+    command tmux "$@"
+  fi
+}
 
 # Load NVM
 export NVM_DIR="$HOME/.nvm"


### PR DESCRIPTION
## Summary
Opening tmux with no args should always land you in the persistent \`planning\` session (matching the existing prefix+C-p keybinding), never create a new throwaway numbered session. Overrides \`tmux\` as a shell function:
- \`tmux\` (no args) → \`tmux attach -t planning\`, creating the session if absent
- \`tmux <anything else>\` → passes straight through to the real binary, unaffected

Found 4 stray empty numbered sessions (5, 6, 8, 9) from this exact issue; cleaned them up locally.

🤖 Generated with [Copilot CLI](https://github.com/github/copilot-cli)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>