### PR TITLE
Fix fzf shell init: stop 'unknown option: --zsh' on new shells

### DIFF
--- a/.fzf.bash
+++ b/.fzf.bash
@@ -1,7 +1,13 @@
 # Setup fzf
 # ---------
-if [[ ! "$PATH" == */home/edd/.fzf/bin* ]]; then
-  PATH="${PATH:+${PATH}:}/home/edd/.fzf/bin"
+# Prefer a user-local fzf (e.g. ~/.local/bin) over an older system one so the
+# shell-integration flag (`fzf --bash`, added in fzf 0.48) is available.
+if [[ -d "$HOME/.local/bin" && ! "$PATH" == *"$HOME/.local/bin"* ]]; then
+  PATH="$HOME/.local/bin:$PATH"
 fi
 
-eval "$(fzf --bash)"
+# Only load integration if the resolved fzf supports `--bash`; older builds
+# (e.g. Debian 0.44) print "unknown option: --bash" on every new shell.
+if command -v fzf >/dev/null 2>&1 && fzf --bash >/dev/null 2>&1; then
+  eval "$(fzf --bash)"
+fi

--- a/.fzf.zsh
+++ b/.fzf.zsh
@@ -1,7 +1,13 @@
 # Setup fzf
 # ---------
-if [[ ! "$PATH" == */home/edd/.fzf/bin* ]]; then
-  PATH="${PATH:+${PATH}:}/home/edd/.fzf/bin"
+# Prefer a user-local fzf (e.g. ~/.local/bin) over an older system one so the
+# shell-integration flag (`fzf --zsh`, added in fzf 0.48) is available.
+if [[ -d "$HOME/.local/bin" && ! "$PATH" == *"$HOME/.local/bin"* ]]; then
+  PATH="$HOME/.local/bin:$PATH"
 fi
 
-source <(fzf --zsh)
+# Only load integration if the resolved fzf supports `--zsh`; older builds
+# (e.g. Debian 0.44) print "unknown option: --zsh" on every new shell.
+if command -v fzf >/dev/null 2>&1 && fzf --zsh >/dev/null 2>&1; then
+  source <(fzf --zsh)
+fi


### PR DESCRIPTION
## Problem
Every new zsh/bash session printed `unknown option: --zsh`.

System `fzf` is **0.44.1** (`/usr/bin`, no `--zsh`/`--bash` integration flag) and sat ahead of the modern **0.73.1** in `~/.local/bin` on PATH, so `source <(fzf --zsh)` hit the old binary. The init also prepended a bogus `/home/edd/.fzf/bin` (wrong user).

## Fix
`.fzf.zsh` and `.fzf.bash` now:
- Prepend `~/.local/bin` so the modern fzf wins.
- Guard the integration behind a support check (skip silently on old fzf).
- Drop the stale `/home/edd/.fzf/bin` PATH entry.

## Verify
New `zsh -i` no longer emits the error; `fzf` resolves to 0.73.1.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>