### PR TITLE
feat: add Fedora support (dnf + rpm-ostree/atomic)

### DIFF
--- a/.bin/setup/common.sh
+++ b/.bin/setup/common.sh
@@ -572,6 +572,20 @@ ensure_tmux_version() {
             track_failure "tmux" "Failed to install tmux build dependencies"
             return 1
         }
+    elif command -v rpm-ostree &> /dev/null || command -v dnf &> /dev/null; then
+        # Fedora / rpm-ostree: layer on atomic, dnf on traditional.
+        local _tmux_deps=(libevent-devel ncurses-devel gcc make bison pkgconf-pkg-config)
+        if [[ -f /run/ostree-booted ]]; then
+            sudo rpm-ostree install --idempotent --allow-inactive --apply-live -y "${_tmux_deps[@]}" || {
+                track_failure "tmux" "Failed to install tmux build dependencies"
+                return 1
+            }
+        else
+            sudo dnf install -y "${_tmux_deps[@]}" || {
+                track_failure "tmux" "Failed to install tmux build dependencies"
+                return 1
+            }
+        fi
     else
         sudo apt-get install -y libevent-dev ncurses-dev build-essential bison pkg-config || {
             track_failure "tmux" "Failed to install tmux build dependencies"

--- a/.bin/setup/fedora.sh
+++ b/.bin/setup/fedora.sh
@@ -1,0 +1,67 @@
+#!/bin/zsh
+# Fedora platform setup. Handles BOTH flavours of Fedora:
+#   * traditional (Workstation/Server/Spins) — mutable /usr, packages via dnf.
+#   * atomic / rpm-ostree (Silverblue, Kinoite, COSMIC Atomic, …) — /usr is
+#     read-only and host packages are LAYERED with rpm-ostree instead of dnf.
+# The distinction is made once by _fedora_is_atomic and everything routes through
+# fedora_pkg_install so the rest of the setup doesn't care which flavour it's on.
+
+# rpm-ostree systems ship an /run/ostree-booted marker; that's the canonical test.
+_fedora_is_atomic() {
+    [[ -f /run/ostree-booted ]]
+}
+
+# fedora_pkg_install <pkg…> — install host packages the right way for this flavour.
+#   Atomic:      layer with rpm-ostree. --apply-live lands them on the RUNNING
+#                system with no reboot; --idempotent skips already-layered pkgs;
+#                --allow-inactive lets us request pkgs already provided by the
+#                base image without erroring. Layering is expensive per call, so
+#                callers should batch everything into ONE invocation.
+#   Traditional: plain `dnf install`.
+fedora_pkg_install() {
+    local pkgs=("$@")
+    [[ ${#pkgs[@]} -eq 0 ]] && return 0
+
+    if _fedora_is_atomic; then
+        echo "Layering packages via rpm-ostree (atomic Fedora): ${pkgs[*]}"
+        if ! sudo rpm-ostree install --idempotent --allow-inactive --apply-live -y "${pkgs[@]}"; then
+            track_failure "rpm-ostree" "Failed to layer packages: ${pkgs[*]}"
+            return 1
+        fi
+    else
+        echo "Installing packages via dnf: ${pkgs[*]}"
+        if ! sudo dnf install -y "${pkgs[@]}"; then
+            track_failure "dnf" "Failed to install packages: ${pkgs[*]}"
+            return 1
+        fi
+    fi
+}
+
+# The shared common_software list uses names that all exist verbatim in Fedora
+# repos (git stow make cmake ripgrep tmux zsh unzip tree jq). Fedora-specific
+# extras cover man pages, secret storage, and the toolchain that the from-source
+# tmux fallback (ensure_tmux_version) needs. neovim + fzf are intentionally NOT
+# layered here — install_neovim/install_fzf fetch newer builds into ~/.local/bin.
+install_fedora_packages() {
+    local fedora_extras=(
+        gcc bison pkgconf-pkg-config
+        libevent-devel ncurses-devel
+        man-db man-pages
+        libsecret curl fd-find bat
+    )
+    # One transaction: cheap on dnf, essential on rpm-ostree.
+    fedora_pkg_install "${common_software[@]}" "${fedora_extras[@]}"
+}
+
+setup_fedora() {
+    install_fedora_packages
+    ensure_tmux_version      # Fedora repo tmux (>=3.5) satisfies the floor; no source build
+    install_neovim
+    install_fzf
+    install_nvm
+    install_lazygit
+    install_claude_code
+    install_playwright
+    setup_python
+    setup_symlinks
+}

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -28,7 +28,9 @@ err() { printf '\033[1;31m[bootstrap]\033[0m %s\n' "$*" >&2; }
 
 # Resolve the package manager just well enough to install git/zsh/curl.
 detect_pm() {
-  if command -v apt-get >/dev/null 2>&1; then echo apt
+  if [ -f /run/ostree-booted ] && command -v rpm-ostree >/dev/null 2>&1; then echo rpm-ostree
+  elif command -v apt-get >/dev/null 2>&1; then echo apt
+  elif command -v dnf     >/dev/null 2>&1; then echo dnf
   elif command -v pacman  >/dev/null 2>&1; then echo pacman
   elif command -v brew    >/dev/null 2>&1; then echo brew
   elif [ "$(uname)" = "Darwin" ]; then echo mac
@@ -41,11 +43,13 @@ ensure_pkg() {
   command -v "$1" >/dev/null 2>&1 && return 0
   log "installing $2…"
   case "$(detect_pm)" in
-    apt)    sudo apt-get update -y && sudo apt-get install -y "$2" ;;
-    pacman) sudo pacman -S --noconfirm "$2" ;;
-    brew)   brew install "$2" ;;
-    mac)    err "Xcode Command Line Tools needed for '$1'. Run: xcode-select --install"; exit 1 ;;
-    *)      err "No supported package manager found to install '$2'."; exit 1 ;;
+    apt)        sudo apt-get update -y && sudo apt-get install -y "$2" ;;
+    dnf)        sudo dnf install -y "$2" ;;
+    rpm-ostree) sudo rpm-ostree install --idempotent --allow-inactive --apply-live -y "$2" ;;
+    pacman)     sudo pacman -S --noconfirm "$2" ;;
+    brew)       brew install "$2" ;;
+    mac)        err "Xcode Command Line Tools needed for '$1'. Run: xcode-select --install"; exit 1 ;;
+    *)          err "No supported package manager found to install '$2'."; exit 1 ;;
   esac
 }
 

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ Python setup (venv + pynvim/requests, and on Ubuntu the `python3.10` /
 SETUP_PYTHON=1 ./setup.sh
 ```
 
-Auto-detects platform (macOS, Ubuntu, Arch, Codespaces) and installs packages, configs, and symlinks via [GNU Stow](https://www.gnu.org/software/stow/).
+Auto-detects platform (macOS, Ubuntu, Arch, Fedora, Codespaces) and installs packages, configs, and symlinks via [GNU Stow](https://www.gnu.org/software/stow/). On atomic/rpm-ostree Fedora variants (Silverblue, Kinoite, COSMIC Atomic) host packages are layered with `rpm-ostree --apply-live` instead of `dnf`.
 
 After setup, optionally run:
 

--- a/setup.sh
+++ b/setup.sh
@@ -98,6 +98,8 @@ run_platform_setup() {
     case "$distro" in
         ubuntu|debian) source "$SCRIPT_DIR/.bin/setup/ubuntu.sh"; setup_ubuntu ;;
         arch)          source "$SCRIPT_DIR/.bin/setup/arch.sh";   setup_arch ;;
+        fedora|rhel|centos|rocky|almalinux)
+                       source "$SCRIPT_DIR/.bin/setup/fedora.sh"; setup_fedora ;;
         codespace)     source "$SCRIPT_DIR/.bin/setup/ubuntu.sh"; setup_codespace ;;
         darwin)
             source "$SCRIPT_DIR/.bin/setup/mac.sh"
@@ -115,7 +117,7 @@ main() {
     local distro=$(detect_distro)
 
     case "$distro" in
-        ubuntu|debian|arch|codespace|darwin|termux) ;;
+        ubuntu|debian|arch|fedora|rhel|centos|rocky|almalinux|codespace|darwin|termux) ;;
         *) track_failure "distro" "Unsupported distribution: $distro"; print_failure_summary; exit 1 ;;
     esac
 


### PR DESCRIPTION
Auto-detect Fedora (and RHEL/CentOS/Rocky/Alma) and install packages the
right way for the variant:

- New .bin/setup/fedora.sh with setup_fedora. _fedora_is_atomic detects
  rpm-ostree/immutable variants (Silverblue, Kinoite, COSMIC Atomic) via
  /run/ostree-booted; fedora_pkg_install layers with
  'rpm-ostree install --idempotent --allow-inactive --apply-live' there
  (no reboot) and uses 'dnf install' on traditional Fedora.
- Wire fedora/rhel/centos/rocky/almalinux into setup.sh (whitelist +
  run_platform_setup dispatch).
- ensure_tmux_version: add a Fedora/rpm-ostree build-deps branch for the
  from-source tmux fallback.
- bootstrap.sh: detect dnf + rpm-ostree so a fresh atomic box can install
  git/zsh/curl before prep runs.
- readme: note Fedora + atomic layering.

Verified live on Fedora 44 COSMIC Atomic: package layering, tmux 3.7b
(>=3.5 floor), neovim + fzf installers all succeed with 0 failures.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
BN-Note: dotfiles/fedora-support
BN-Decision: Fedora support: rpm-ostree --idempotent --allow-inactive --apply-live for atomic variants, dnf for traditional; verified live on Fedora 44 COSMIC Atomic box
